### PR TITLE
No memory allocation for each C_DecryptUpdate.

### DIFF
--- a/src/lib/crypto/SymmetricAlgorithm.cpp
+++ b/src/lib/crypto/SymmetricAlgorithm.cpp
@@ -121,7 +121,9 @@ bool SymmetricAlgorithm::decryptUpdate(const ByteString& encryptedData, ByteStri
 	}
 
 	currentBufferSize += encryptedData.size();
-	currentAEADBuffer += encryptedData;
+	if (currentCipherMode == SymMode::GCM) {
+		currentAEADBuffer += encryptedData;
+	}
 
 	return true;
 }


### PR DESCRIPTION
Before this change the allocated memory was growing after each
C_DecryptUpdate.
If a large amount of data is decrypted then the memory runs out ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decryption handling to ensure encrypted data is only buffered in GCM mode, enhancing reliability for users in certain encryption scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->