### PR TITLE
Fix severe peformance issue accessing keys

### DIFF
--- a/src/lib/object_store/Generation.cpp
+++ b/src/lib/object_store/Generation.cpp
@@ -35,7 +35,7 @@
 #include "Generation.h"
 
 // Factory
-Generation* Generation::create(const std::string path, int umask, bool isToken /* = false */)
+Generation* Generation::create(const std::string path, int umask, bool isToken)
 {
 	Generation* gen = new Generation(path, umask, isToken);
 	if ((gen != NULL) && isToken && (gen->genMutex == NULL))

--- a/src/lib/object_store/Generation.h
+++ b/src/lib/object_store/Generation.h
@@ -42,7 +42,7 @@ class Generation
 {
 public:
 	// Factory
-	static Generation* create(const std::string inPath, int inUmask, bool inIsToken = false);
+	static Generation* create(const std::string inPath, int inUmask, bool inIsToken);
 
 	// Destructor
 	virtual ~Generation();

--- a/src/lib/object_store/OSToken.cpp
+++ b/src/lib/object_store/OSToken.cpp
@@ -57,7 +57,7 @@ OSToken::OSToken(const std::string inTokenPath, int inUmask)
 	umask = inUmask;
 
 	tokenDir = new Directory(tokenPath);
-	gen = Generation::create(tokenPath + OS_PATHSEP + "generation", true);
+	gen = Generation::create(tokenPath + OS_PATHSEP + "generation", umask, true);
 	tokenObject = new ObjectFile(this, tokenPath + OS_PATHSEP + "token.object", umask, tokenPath + OS_PATHSEP + "token.lock");
 	tokenMutex = MutexFactory::i()->getMutex();
 	valid = (gen != NULL) && (tokenMutex != NULL) && tokenDir->isValid() && tokenObject->valid;

--- a/src/lib/object_store/ObjectFile.cpp
+++ b/src/lib/object_store/ObjectFile.cpp
@@ -53,7 +53,7 @@ ObjectFile::ObjectFile(OSToken* parent, std::string inPath, int inUmask, std::st
 {
 	path = inPath;
 	umask = inUmask;
-	gen = Generation::create(path, umask);
+	gen = Generation::create(path, umask, false);
 	objectMutex = MutexFactory::i()->getMutex();
 	valid = (gen != NULL) && (objectMutex != NULL);
 	token = parent;


### PR DESCRIPTION
The "true" in the call to Generation::create() in OSToken::OSToken() is
used as the umask when it's supposed to be the isToken value (#566).

Remove the default value from isToken because it's dangerous and there are
only two callers. Explicitly pass "true" and "false" for isToken.

Failing to consider this a token generation file means that the value is
never refreshed for read-only operations. All objects are reloaded from
disk every time one of them is refreshed. List operations take a long time
because all of the objects are re-read for each object.

Fixes #680.