### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,31 @@ jobs:
         run: |
           make check || (find . -name test-suite.log -exec cat {} \; && false)
 
+  macos:
+    name: macOS (${{ matrix.backend }})
+    runs-on: macos-12
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - backend: openssl
+            extra-options: --with-openssl=$(brew --prefix openssl@1.1)
+          - backend: botan
+            extra-options: --with-botan=$(brew --prefix botan@2)
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare
+        run: |
+          brew install automake cppunit botan@2
+      - name: Build
+        run: |
+          ./autogen.sh
+          ./configure --with-crypto-backend=${{ matrix.backend }} ${{ matrix.extra-options }}
+          make
+      - name: Test
+        run: |
+          make check || (find . -name test-suite.log -exec cat {} \; && false)
+
   windows:
     name: Windows (${{ matrix.arch }}, ${{ matrix.backend }})
     runs-on: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           arch: ${{ matrix.arch }}
       - name: Create vcpkg.json
         run: >
-          echo '{ "dependencies": [ "openssl", "botan" ],
+          echo '{ "dependencies": [ "openssl", "botan", "cppunit" ],
                   "overrides": [ { "name": "openssl", "version-string": "1.1.1n" },
                                  { "name": "botan",   "version-string": "2.19.3" } ],
                   "builtin-baseline": "38d1652f152d36481f2f4e8a85c0f1e14f3769f7" }' > vcpkg.json
@@ -63,5 +63,10 @@ jobs:
       - name: Build
         run: |
           mkdir build
-          cmake -B build ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -A ${{ matrix.target-platform }} -DWITH_CRYPTO_BACKEND=${{ matrix.backend }} -DDISABLE_NON_PAGED_MEMORY=ON
+          cmake -B build ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -A ${{ matrix.target-platform }} -DWITH_CRYPTO_BACKEND=${{ matrix.backend }} -DDISABLE_NON_PAGED_MEMORY=ON -DBUILD_TESTS=ON
           cmake --build build
+      - name: Test
+        env:
+          CTEST_OUTPUT_ON_FAILURE: 1
+        run: |
+          cmake --build build --target RUN_TESTS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  linux:
+    name: Linux (${{ matrix.backend }})
+    runs-on: ubuntu-20.04 # for OpenSSL 1.1.1
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - backend: openssl
+          - backend: botan
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare
+        run: |
+          sudo apt update -qq
+          sudo apt install libcppunit-dev libbotan-2-dev p11-kit
+      - name: Build
+        run: |
+          ./autogen.sh
+          ./configure --with-crypto-backend=${{ matrix.backend }}
+          make
+      - name: Test
+        run: |
+          make check || (find . -name test-suite.log -exec cat {} \; && false)
+
+  windows:
+    name: Windows (${{ matrix.arch }}, ${{ matrix.backend }})
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            backend: openssl
+            target-platform: x64
+          - arch: x64
+            backend: botan
+            target-platform: x64
+          - arch: x86
+            backend: openssl
+            target-platform: Win32
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.arch }}
+      - name: Create vcpkg.json
+        run: >
+          echo '{ "dependencies": [ "openssl", "botan" ],
+                  "overrides": [ { "name": "openssl", "version-string": "1.1.1n" },
+                                 { "name": "botan",   "version-string": "2.19.3" } ],
+                  "builtin-baseline": "38d1652f152d36481f2f4e8a85c0f1e14f3769f7" }' > vcpkg.json
+      - uses: seanmiddleditch/vcpkg-action@master
+        id: vcpkg
+        with:
+          manifest-dir: ${{ github.workspace }}
+          triplet: ${{ matrix.arch }}-windows
+          token: ${{ github.token }}
+      - name: Build
+        run: |
+          mkdir build
+          cmake -B build ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -A ${{ matrix.target-platform }} -DWITH_CRYPTO_BACKEND=${{ matrix.backend }} -DDISABLE_NON_PAGED_MEMORY=ON
+          cmake --build build

--- a/src/lib/test/CMakeLists.txt
+++ b/src/lib/test/CMakeLists.txt
@@ -32,10 +32,12 @@ set(SOURCES p11test.cpp
 add_executable(${PROJECT_NAME} ${SOURCES})
 			
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    list(APPEND SOURCES ${PROJECT_SOURCE_DIR}/../win32/setenv.cpp ${PROJECT_SOURCE_DIR}/../win32/syslog.cpp)
+    target_sources(${PROJECT_NAME} PRIVATE
+                   ${PROJECT_SOURCE_DIR}/../win32/setenv.cpp
+                   ${PROJECT_SOURCE_DIR}/../win32/syslog.cpp)
     list(APPEND COMPILE_OPTIONS "/DCRYPTOKI_STATIC")
 else()
-    list(APPEND SOURCES "ForkTests.cpp")
+    target_sources(${PROJECT_NAME} PRIVATE "ForkTests.cpp")
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS -pthread)
 endif()
 
@@ -43,7 +45,6 @@ include_directories(${INCLUDE_DIRS})
 
 
 target_link_libraries(${PROJECT_NAME} softhsm2-static ${SQLITE3_LIBS} ${CPPUNIT_LIBRARIES})
-set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS -pthread)
 
 target_compile_options(${PROJECT_NAME} PRIVATE ${COMPILE_OPTIONS})
 


### PR DESCRIPTION
Since Travis CI is no longer free as before, and there are issues with AppVeyor we currently don't have a working CI.
This PR adds a basic CI run which build and run tests for both crypto backends on Linux, Mac and Windows.

An example run: https://github.com/Nordix/SoftHSMv2/actions/runs/7718456304
The failed botan run is related to #724

Windows vcpkg's are cached for faster builds, but there are a lot of other improvements that could be done to this CI.
Examples are running sanitizers/valgrind/Coverity on Linux or using later OpenSSL version.

In general we would like to support this project, and adding a CI which can indicate existing issues is a start.
WDYT @halderen @rijswijk @jschlyter ?