### PR TITLE
Fix Botan build and test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,12 +67,15 @@ jobs:
           - arch: x64
             backend: openssl
             target-platform: x64
+            build-options:
           - arch: x64
             backend: botan
             target-platform: x64
+            build-options: -DENABLE_ECC=OFF -DENABLE_EDDSA=OFF
           - arch: x86
             backend: openssl
             target-platform: Win32
+            build-options: -DENABLE_ECC=OFF -DENABLE_EDDSA=OFF
     steps:
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
@@ -93,7 +96,7 @@ jobs:
       - name: Build
         run: |
           mkdir build
-          cmake -B build ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -A ${{ matrix.target-platform }} -DWITH_CRYPTO_BACKEND=${{ matrix.backend }} -DDISABLE_NON_PAGED_MEMORY=ON -DBUILD_TESTS=ON
+          cmake -B build ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -A ${{ matrix.target-platform }} -DWITH_CRYPTO_BACKEND=${{ matrix.backend }} ${{ matrix.build-options }} -DDISABLE_NON_PAGED_MEMORY=ON -DBUILD_TESTS=ON
           cmake --build build
       - name: Test
         env:

--- a/src/lib/crypto/BotanSymmetricAlgorithm.cpp
+++ b/src/lib/crypto/BotanSymmetricAlgorithm.cpp
@@ -169,7 +169,26 @@ bool BotanSymmetricAlgorithm::encryptInit(const SymmetricKey* key, const SymMode
 	try
 	{
 		Botan::SymmetricKey botanKey = Botan::SymmetricKey(key->getKeyBits().const_byte_str(), key->getKeyBits().size());
-		if (mode == SymMode::GCM)
+		if (mode == SymMode::ECB)
+		{
+			// ECB cipher mode was dropped in Botan 2.0
+			const std::vector<std::string> algo_parts = split_on_delim(cipherName, '/');
+			const std::string cipher_name = algo_parts[0];
+			bool with_pkcs7_padding;
+			if (algo_parts.size() == 3 && algo_parts[2] == "PKCS7")
+			{
+				with_pkcs7_padding = true;
+			}
+			else
+			{
+				with_pkcs7_padding = false;
+			}
+			std::unique_ptr<Botan::BlockCipher> bc(Botan::BlockCipher::create(cipher_name));
+			Botan::Keyed_Filter* cipher = new Botan::Cipher_Mode_Filter(new Botan::ECB_Encryption(bc.release(), with_pkcs7_padding));
+			cipher->set_key(botanKey);
+			cryption = new Botan::Pipe(cipher);
+		}
+		else if (mode == SymMode::GCM)
 		{
 			Botan::AEAD_Mode* aead = Botan::get_aead(cipherName, Botan::ENCRYPTION);
 			aead->set_key(botanKey);
@@ -385,7 +404,26 @@ bool BotanSymmetricAlgorithm::decryptInit(const SymmetricKey* key, const SymMode
 	try
 	{
 		Botan::SymmetricKey botanKey = Botan::SymmetricKey(key->getKeyBits().const_byte_str(), key->getKeyBits().size());
-		if (mode == SymMode::GCM)
+		if (mode == SymMode::ECB)
+		{
+			// ECB cipher mode was dropped in Botan 2.0
+			const std::vector<std::string> algo_parts = split_on_delim(cipherName, '/');
+			const std::string cipher_name = algo_parts[0];
+			bool with_pkcs7_padding;
+			if (algo_parts.size() == 3 && algo_parts[2] == "PKCS7")
+			{
+				with_pkcs7_padding = true;
+			}
+			else
+			{
+				with_pkcs7_padding = false;
+			}
+			std::unique_ptr<Botan::BlockCipher> bc(Botan::BlockCipher::create(cipher_name));
+			Botan::Keyed_Filter* cipher = new Botan::Cipher_Mode_Filter(new Botan::ECB_Decryption(bc.release(),with_pkcs7_padding));
+			cipher->set_key(botanKey);
+			cryption = new Botan::Pipe(cipher);
+		}
+		else if (mode == SymMode::GCM)
 		{
 			Botan::AEAD_Mode* aead = Botan::get_aead(cipherName, Botan::DECRYPTION);
 			aead->set_key(botanKey);

--- a/src/lib/crypto/Botan_ecb.h
+++ b/src/lib/crypto/Botan_ecb.h
@@ -22,7 +22,7 @@ namespace Botan {
 /**
 * ECB mode
 */
-class BOTAN_DLL ECB_Mode : public Cipher_Mode
+class ECB_Mode : public Cipher_Mode
    {
    public:
       std::string name() const override;
@@ -57,7 +57,7 @@ class BOTAN_DLL ECB_Mode : public Cipher_Mode
 /**
 * ECB Encryption
 */
-class BOTAN_DLL ECB_Encryption final : public ECB_Mode
+class ECB_Encryption final : public ECB_Mode
    {
    public:
       /**
@@ -78,7 +78,7 @@ class BOTAN_DLL ECB_Encryption final : public ECB_Mode
 /**
 * ECB Decryption
 */
-class BOTAN_DLL ECB_Decryption final : public ECB_Mode
+class ECB_Decryption final : public ECB_Mode
    {
    public:
       /**

--- a/src/lib/crypto/CMakeLists.txt
+++ b/src/lib/crypto/CMakeLists.txt
@@ -95,6 +95,7 @@ if(WITH_BOTAN)
                         BotanDSAKeyPair.cpp
                         BotanDSAPrivateKey.cpp
                         BotanDSAPublicKey.cpp
+                        Botan_ecb.cpp
                         BotanECDH.cpp
                         BotanECDHKeyPair.cpp
                         BotanECDHPrivateKey.cpp

--- a/src/lib/test/SymmetricAlgorithmTests.cpp
+++ b/src/lib/test/SymmetricAlgorithmTests.cpp
@@ -1427,8 +1427,10 @@ void SymmetricAlgorithmTests::aesWrapUnwrapED(CK_MECHANISM_TYPE mechanismType, C
 	CK_BBOOL bTrue = CK_TRUE;
 
 	std::map<std::string, EDCurveParam > curves {
-		{ "ED25519", {0x06, 0x03, 0x2b, 0x65, 0x70} },
-		{ "ED448", {0x06, 0x03, 0x2b, 0x65, 0x71} }
+		{ "ED25519", {0x06, 0x03, 0x2b, 0x65, 0x70} }
+#ifndef WITH_BOTAN
+		, { "ED448", {0x06, 0x03, 0x2b, 0x65, 0x71} }
+#endif
 	};
 
 	for(auto &curve : curves) {


### PR DESCRIPTION
This PR includes the following commits to be able to run all tests on the different platforms in CI.

* Revert removal of Botan 2.0 ECB handling 
    The ECB handling was added when Botan 2.0 was introduced via:
     https://github.com/softhsm/SoftHSMv2/pull/294
    
    but then removed by comments in (and later removed completely):
      https://github.com/softhsm/SoftHSMv2/pull/717 via: https://github.com/softhsm/SoftHSMv2/commit/8fd89ec33edfe4a7b510c471101f78b52a0c1294
    
    This commit reverts parts of this commit to get a stable state.
     We could remove it fully in a separate PR, but then we should also remove the files Botan_ecb.h and Botan_ecb.cpp,
    and avoid running some tests on Botan.

* Correcting build options for Windows in CI 
    The CI installed libraries `Botan` and `OpenSSL` (x86 only) lacks support for `ECC` and `EDDSA`,
    which now are disabled during the CI builds. This fixes the build errors.
    Windows x64 with OpenSSL still builds and runs these tests.

* Remove testing of unsupported `ED448` in Botan 2  
    The test can be re-enabled when we support Botan 3, see https://github.com/randombit/botan/pull/3933
 Today we only support Botan 2 in autoconf/CMake.




Fixes #767