### PR TITLE
Add configure option and code to disable OpenSSL engines

### DIFF
--- a/m4/acx_crypto_backend.m4
+++ b/m4/acx_crypto_backend.m4
@@ -49,6 +49,16 @@ AC_DEFUN([ACX_CRYPTO_BACKEND],[
 		AC_MSG_RESULT(no)
 	fi
 
+	# Option to disable usage engines
+
+	AC_ARG_ENABLE(openssl-engines,
+		AS_HELP_STRING([--disable-openssl-engines],
+			[Disable OpenSSL engines usage]
+		),
+		[enable_openssl_engines="${enableval}"],
+		[enable_openssl_engines="yes"]
+	)
+
 	# Then check what crypto library we want to use
 
 	AC_ARG_WITH(crypto-backend,
@@ -103,6 +113,22 @@ AC_DEFUN([ACX_CRYPTO_BACKEND],[
 			ACX_OPENSSL_FIPS
 		else
 			ACX_OPENSSL_EVPAESWRAP
+		fi
+
+		AC_MSG_CHECKING(for OpenSSL engines support)
+		if test "x${enable_openssl_engines}" = "xyes"; then
+			ACX_OPENSSL_ENGINES
+			if test "x${have_lib_openssl_engines_support}" = "xyes"; then
+				AC_MSG_RESULT([yes])
+			else
+				AC_MSG_RESULT([no])
+				AC_DEFINE_UNQUOTED([WITHOUT_OPENSSL_ENGINES], [1],
+					[Compile without OpenSSL engines support as it is unavailable])
+			fi
+		else
+			AC_MSG_RESULT([disabled])
+			AC_DEFINE([WITHOUT_OPENSSL_ENGINES], [1],
+				[Compile without OpenSSL engines support as it is disabled])
 		fi
 
 		AC_DEFINE_UNQUOTED(

--- a/m4/acx_openssl_engines.m4
+++ b/m4/acx_openssl_engines.m4
@@ -1,0 +1,35 @@
+AC_DEFUN([ACX_OPENSSL_ENGINES], [
+
+    tmp_CPPFLAGS=$CPPFLAGS
+    tmp_LIBS=$LIBS
+
+    CPPFLAGS="$CPPFLAGS $CRYPTO_INCLUDES"
+    LIBS="$CRYPTO_LIBS $LIBS"
+
+    AC_LANG_PUSH([C])
+    AC_CACHE_VAL([acx_cv_lib_openssl_engines_support], [
+        acx_cv_lib_openssl_engines_support=no
+        AC_COMPILE_IFELSE([
+            AC_LANG_SOURCE([[
+                #include <openssl/engine.h>
+                #ifdef OPENSSL_NO_ENGINE
+                #error "Engines are disabled"
+                #endif
+                int main() {
+                    ENGINE_load_builtin_engines();
+                    return 0;
+                }
+            ]])
+        ], [
+            acx_cv_lib_openssl_engines_support=yes
+        ], [
+            acx_cv_lib_openssl_engines_support=no
+        ])
+    ])
+    AC_LANG_POP([C])
+
+    CPPFLAGS=$tmp_CPPFLAGS
+    LIBS=$tmp_LIBS
+
+    have_lib_openssl_engines_support="${acx_cv_lib_openssl_engines_support}"
+])

--- a/src/lib/crypto/OSSLCryptoFactory.h
+++ b/src/lib/crypto/OSSLCryptoFactory.h
@@ -42,7 +42,11 @@
 #include "RNG.h"
 #include <memory>
 #include <openssl/conf.h>
+#if !defined(WITHOUT_OPENSSL_ENGINES) && !defined(OPENSSL_NO_ENGINES)
+#define WITH_ENGINES 1
 #include <openssl/engine.h>
+#endif
+
 
 class OSSLCryptoFactory : public CryptoFactory
 {
@@ -103,12 +107,15 @@ private:
 
 	// The one-and-only RNG instance
 	RNG* rng;
+
+#ifdef WITH_ENGINES
 	// And RDRAND engine to use with it
 	ENGINE *rdrand_engine;
 
 #ifdef WITH_GOST
 	// The GOST engine
 	ENGINE *eg;
+#endif
 #endif
 };
 


### PR DESCRIPTION
This is to disable OpenSSL engines that are deprecated and in some setups inconvenient - especially the rdrand default usage which has priority over providers and disallows overwriting random generator using custom providers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added configuration option to disable OpenSSL engines
	- Enhanced control over cryptographic engine initialization

- **Bug Fixes**
	- Improved error handling for cryptographic engine loading
	- Prevented potential null pointer dereferences during engine cleanup

- **Refactor**
	- Modularized OpenSSL engine support with conditional compilation
	- Updated initialization and cleanup processes for cryptographic engines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->