### PR TITLE
Replace deprecated Github runner ubuntu-20.04 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   linux:
     name: Linux (${{ matrix.backend }})
-    runs-on: ubuntu-20.04 # for OpenSSL 1.1.1
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -23,6 +23,13 @@ jobs:
         run: |
           sudo apt update -qq
           sudo apt install libcppunit-dev libbotan-2-dev p11-kit
+          # Replace installed OpenSSL with the supported version 1.1.1
+          curl -O http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb
+          curl -O http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.1.1f-1ubuntu2.24_amd64.deb
+          curl -O http://security.ubuntu.com/ubuntu/pool/main/o/openssl/openssl_1.1.1f-1ubuntu2.24_amd64.deb
+          sudo dpkg -i --force-confnew openssl_1.1.1f-1ubuntu2.24_amd64.deb \
+                                       libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb \
+                                       libssl-dev_1.1.1f-1ubuntu2.24_amd64.deb
       - name: Build
         env:
           CXXFLAGS: -Werror -DBOTAN_NO_DEPRECATED_WARNINGS


### PR DESCRIPTION
Replace deprecated Github runner `ubuntu-20.04` with `ubuntu-24.04`

When running with a newer ubuntu a new issue surfaces with the fork test,
which probably is due to the lift of GLIBC, from v2.31 to v2.34.
Others have [this](https://sourceware.org/bugzilla/show_bug.cgi?id=4737) related issue.

An fix for this is to wait for spawned fork-tests to avoid any race conditions.
Each spawned testcase is now exited to avoid running the tests multiple times.
    


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to use Ubuntu 24.04 and ensured compatibility by installing required OpenSSL packages.

* **Tests**
  * Improved process handling and validation in fork-related tests to ensure proper cleanup and verification of child process completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->