### PR TITLE
Added SoftHSMv2 contributors copyright headers

### DIFF
--- a/cmake/modules/tests/test_openssl_mldsa.c
+++ b/cmake/modules/tests/test_openssl_mldsa.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 #include <openssl/evp.h>
 #include <openssl/objects.h>
 int main()

--- a/cmake/modules/tests/test_openssl_mlkem.c
+++ b/cmake/modules/tests/test_openssl_mlkem.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 #include <openssl/evp.h>
 #include <openssl/objects.h>
 int main()

--- a/src/bin/util/softhsm2-util-ossl.cpp
+++ b/src/bin/util/softhsm2-util-ossl.cpp
@@ -23,7 +23,11 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  softhsm2-util-ossl.cpp
 

--- a/src/bin/util/softhsm2-util-ossl.h
+++ b/src/bin/util/softhsm2-util-ossl.h
@@ -23,7 +23,11 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  softhsm2-util-ossl.h
 

--- a/src/bin/util/softhsm2-util.cpp
+++ b/src/bin/util/softhsm2-util.cpp
@@ -23,7 +23,11 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  softhsm2-util.cpp
 

--- a/src/bin/util/test/import-key-test-common.sh
+++ b/src/bin/util/test/import-key-test-common.sh
@@ -1,5 +1,9 @@
 #! /bin/bash
-# This file is in the public domain.
+# 
+# Copyright (c) 2026 SoftHSMv2 contributors
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
 # Common logic for PQC key-pair import tests.
 #
 # Required variables (set by the caller before sourcing this file):

--- a/src/bin/util/test/mldsa44-import-key-test.sh
+++ b/src/bin/util/test/mldsa44-import-key-test.sh
@@ -1,5 +1,9 @@
 #! /bin/bash
-# This file is in the public domain
+# 
+# Copyright (c) 2026 SoftHSMv2 contributors
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
 
 CI_TEST_ENABLED="${MLDSA_TEST}"
 ALGO_NAME="ML-DSA"

--- a/src/bin/util/test/mlkem512-import-key-test.sh
+++ b/src/bin/util/test/mlkem512-import-key-test.sh
@@ -1,5 +1,9 @@
 #! /bin/bash
-# This file is in the public domain
+# 
+# Copyright (c) 2026 SoftHSMv2 contributors
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
 
 CI_TEST_ENABLED="${MLKEM_TEST}"
 ALGO_NAME="ML-KEM"

--- a/src/lib/crypto/MLDSAMechanismParam.cpp
+++ b/src/lib/crypto/MLDSAMechanismParam.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLDSAMechanismParam.cpp
 

--- a/src/lib/crypto/MLDSAMechanismParam.h
+++ b/src/lib/crypto/MLDSAMechanismParam.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLDSAMechanismParam.h
 

--- a/src/lib/crypto/MLDSAParameters.cpp
+++ b/src/lib/crypto/MLDSAParameters.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLDSAParameters.cpp
 

--- a/src/lib/crypto/MLDSAParameters.h
+++ b/src/lib/crypto/MLDSAParameters.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLDSAParameters.h
 

--- a/src/lib/crypto/MLDSAPrivateKey.cpp
+++ b/src/lib/crypto/MLDSAPrivateKey.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLDSAPrivateKey.cpp
 

--- a/src/lib/crypto/MLDSAPrivateKey.h
+++ b/src/lib/crypto/MLDSAPrivateKey.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLDSAPrivateKey.h
 

--- a/src/lib/crypto/MLDSAPublicKey.cpp
+++ b/src/lib/crypto/MLDSAPublicKey.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLDSAPublicKey.cpp
 

--- a/src/lib/crypto/MLDSAPublicKey.h
+++ b/src/lib/crypto/MLDSAPublicKey.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLDSAPublicKey.h
 

--- a/src/lib/crypto/MLDSAUtil.cpp
+++ b/src/lib/crypto/MLDSAUtil.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLDSAUtil.cpp
 

--- a/src/lib/crypto/MLDSAUtil.h
+++ b/src/lib/crypto/MLDSAUtil.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLDSAUtil.h
 

--- a/src/lib/crypto/MLKEMParameters.cpp
+++ b/src/lib/crypto/MLKEMParameters.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLKEMParameters.cpp
 

--- a/src/lib/crypto/MLKEMParameters.h
+++ b/src/lib/crypto/MLKEMParameters.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLKEMParameters.h
 

--- a/src/lib/crypto/MLKEMPrivateKey.cpp
+++ b/src/lib/crypto/MLKEMPrivateKey.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLKEMPrivateKey.cpp
 

--- a/src/lib/crypto/MLKEMPrivateKey.h
+++ b/src/lib/crypto/MLKEMPrivateKey.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLKEMPrivateKey.h
 

--- a/src/lib/crypto/MLKEMPublicKey.cpp
+++ b/src/lib/crypto/MLKEMPublicKey.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLKEMPublicKey.cpp
 

--- a/src/lib/crypto/MLKEMPublicKey.h
+++ b/src/lib/crypto/MLKEMPublicKey.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLKEMPublicKey.h
 

--- a/src/lib/crypto/MLKEMUtil.cpp
+++ b/src/lib/crypto/MLKEMUtil.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLKEMUtil.cpp
 

--- a/src/lib/crypto/MLKEMUtil.h
+++ b/src/lib/crypto/MLKEMUtil.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLKEMUtil.h
 

--- a/src/lib/crypto/MechanismParam.h
+++ b/src/lib/crypto/MechanismParam.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MechanismParam.h
 

--- a/src/lib/crypto/OSSLMLDSA.cpp
+++ b/src/lib/crypto/OSSLMLDSA.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  OSSLMLDSA.cpp
 

--- a/src/lib/crypto/OSSLMLDSA.h
+++ b/src/lib/crypto/OSSLMLDSA.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  OSSLMLDSA.h
 

--- a/src/lib/crypto/OSSLMLDSAKeyPair.cpp
+++ b/src/lib/crypto/OSSLMLDSAKeyPair.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  OSSLMLDSAKeyPair.cpp
 

--- a/src/lib/crypto/OSSLMLDSAKeyPair.h
+++ b/src/lib/crypto/OSSLMLDSAKeyPair.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  OSSLMLDSAKeyPair.h
 

--- a/src/lib/crypto/OSSLMLDSAPrivateKey.cpp
+++ b/src/lib/crypto/OSSLMLDSAPrivateKey.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  OSSLMLDSAPrivateKey.cpp
 

--- a/src/lib/crypto/OSSLMLDSAPrivateKey.h
+++ b/src/lib/crypto/OSSLMLDSAPrivateKey.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  OSSLMLDSAPrivateKey.h
 

--- a/src/lib/crypto/OSSLMLDSAPublicKey.cpp
+++ b/src/lib/crypto/OSSLMLDSAPublicKey.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  OSSLMLDSAPublicKey.cpp
 

--- a/src/lib/crypto/OSSLMLDSAPublicKey.h
+++ b/src/lib/crypto/OSSLMLDSAPublicKey.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  OSSLMLDSAPublicKey.h
 

--- a/src/lib/crypto/OSSLMLKEM.cpp
+++ b/src/lib/crypto/OSSLMLKEM.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  OSSLMLKEM.cpp
 

--- a/src/lib/crypto/OSSLMLKEM.h
+++ b/src/lib/crypto/OSSLMLKEM.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  OSSLMLKEM.h
 

--- a/src/lib/crypto/OSSLMLKEMKeyPair.cpp
+++ b/src/lib/crypto/OSSLMLKEMKeyPair.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  OSSLMLKEMKeyPair.cpp
 

--- a/src/lib/crypto/OSSLMLKEMKeyPair.h
+++ b/src/lib/crypto/OSSLMLKEMKeyPair.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  OSSLMLKEMKeyPair.h
 

--- a/src/lib/crypto/OSSLMLKEMPrivateKey.cpp
+++ b/src/lib/crypto/OSSLMLKEMPrivateKey.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  OSSLMLKEMPrivateKey.cpp
 

--- a/src/lib/crypto/OSSLMLKEMPrivateKey.h
+++ b/src/lib/crypto/OSSLMLKEMPrivateKey.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  OSSLMLKEMPrivateKey.h
 

--- a/src/lib/crypto/OSSLMLKEMPublicKey.cpp
+++ b/src/lib/crypto/OSSLMLKEMPublicKey.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  OSSLMLKEMPublicKey.cpp
 

--- a/src/lib/crypto/OSSLMLKEMPublicKey.h
+++ b/src/lib/crypto/OSSLMLKEMPublicKey.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  OSSLMLKEMPublicKey.h
 

--- a/src/lib/crypto/RSAMechanismParam.cpp
+++ b/src/lib/crypto/RSAMechanismParam.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  RSAMechanismParam.cpp
 

--- a/src/lib/crypto/RSAMechanismParam.h
+++ b/src/lib/crypto/RSAMechanismParam.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  RSAMechanismParam.h
 

--- a/src/lib/crypto/test/MLDSATests.cpp
+++ b/src/lib/crypto/test/MLDSATests.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLDSATests.cpp
 

--- a/src/lib/crypto/test/MLDSATests.h
+++ b/src/lib/crypto/test/MLDSATests.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLDSATests.h
 

--- a/src/lib/crypto/test/MLKEMTests.cpp
+++ b/src/lib/crypto/test/MLKEMTests.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLKEMTests.cpp
 

--- a/src/lib/crypto/test/MLKEMTests.h
+++ b/src/lib/crypto/test/MLKEMTests.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 /*****************************************************************************
  MLKEMTests.h
 


### PR DESCRIPTION
As per @bukka request [here](https://github.com/softhsm/SoftHSMv2/pull/862#pullrequestreview-4539745127) , I have added banners of copyrights on recently created and merged files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated copyright headers and license information across the codebase to reflect 2026 SoftHSMv2 contributors and BSD-2-Clause licensing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->