### PR TITLE
Fix CKA_WRAP_TEMPLATE enforcement for byte-string attributes

### DIFF
--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -7175,7 +7175,28 @@ CK_RV SoftHSM::C_WrapKey
 
 				OSAttribute keyAttr = key->getAttribute(it->first);
 				ByteString v1, v2;
-				if (!keyAttr.peekValue(v1) || !it->second.peekValue(v2) || (v1 != v2))
+				if (!keyAttr.peekValue(v1) || !it->second.peekValue(v2))
+				{
+					return CKR_KEY_NOT_WRAPPABLE;
+				}
+
+				// Byte string attributes of a private object are held
+				// encrypted in the object store, while the template
+				// carries the plaintext supplied by the caller. Decrypt
+				// before comparing, otherwise every byte string entry in
+				// CKA_WRAP_TEMPLATE compares ciphertext against plaintext
+				// and can never match.
+				if (isKeyPrivate && keyAttr.isByteStringAttribute())
+				{
+					ByteString plain;
+					if (!token->decrypt(v1, plain))
+					{
+						return CKR_GENERAL_ERROR;
+					}
+					v1 = plain;
+				}
+
+				if (v1 != v2)
 				{
 					return CKR_KEY_NOT_WRAPPABLE;
 				}

--- a/src/lib/test/AsymWrapUnwrapTests.cpp
+++ b/src/lib/test/AsymWrapUnwrapTests.cpp
@@ -338,3 +338,130 @@ void AsymWrapUnwrapTests::testRsaWrapUnwrap()
 	rsaWrapUnwrap(CKM_RSA_PKCS_OAEP,hSessionRO,hPublicKey,hPrivateKey);
 	rsaWrapUnwrap(CKM_RSA_AES_KEY_WRAP, hSessionRO, hPublicKey, hPrivateKey);
 }
+
+// Reproducer: CKA_WRAP_TEMPLATE entries that carry a byte string value
+// (e.g. CKA_LABEL) must match against the PLAINTEXT attribute of the key
+// being wrapped. Byte string attributes of a private object are stored
+// encrypted, so comparing the raw stored value against the caller supplied
+// template can never match and C_WrapKey wrongly returns
+// CKR_KEY_NOT_WRAPPABLE for a key that does satisfy the template.
+void AsymWrapUnwrapTests::testWrapTemplatePrivateAttribute()
+{
+	CK_RV rv;
+	CK_SESSION_HANDLE hSession;
+	CK_UTF8CHAR label[] = "authorized";
+	CK_UTF8CHAR otherLabel[] = "unauthorized";
+
+	// Just make sure that we finalize any previous tests
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
+
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
+	CPPUNIT_ASSERT_EQUAL(CKR_OK, rv);
+
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID,
+		CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL_PTR, NULL_PTR, &hSession) );
+	CPPUNIT_ASSERT_EQUAL(CKR_OK, rv);
+
+	rv = CRYPTOKI_F_PTR( C_Login(hSession, CKU_USER, m_userPin1, m_userPin1Length) );
+	CPPUNIT_ASSERT_EQUAL(CKR_OK, rv);
+
+	// Wrapping key restricted to secrets labelled "authorized"
+	CK_ATTRIBUTE wrapTemplate[] = {
+		{ CKA_LABEL, label, sizeof(label) - 1 }
+	};
+
+	CK_BBOOL bTrue = CK_TRUE;
+	CK_ULONG modulusBits = 1536;
+	CK_BYTE publicExponent[] = { 0x01, 0x00, 0x01 };
+	CK_MECHANISM keyGenMech = { CKM_RSA_PKCS_KEY_PAIR_GEN, NULL_PTR, 0 };
+
+	CK_ATTRIBUTE pukAttribs[] = {
+		{ CKA_TOKEN, &bTrue, sizeof(bTrue) },
+		{ CKA_WRAP, &bTrue, sizeof(bTrue) },
+		{ CKA_MODULUS_BITS, &modulusBits, sizeof(modulusBits) },
+		{ CKA_PUBLIC_EXPONENT, publicExponent, sizeof(publicExponent) },
+		{ CKA_WRAP_TEMPLATE, wrapTemplate, sizeof(wrapTemplate) }
+	};
+	CK_ATTRIBUTE prkAttribs[] = {
+		{ CKA_TOKEN, &bTrue, sizeof(bTrue) },
+		{ CKA_PRIVATE, &bTrue, sizeof(bTrue) },
+		{ CKA_UNWRAP, &bTrue, sizeof(bTrue) }
+	};
+
+	CK_OBJECT_HANDLE hPuk = CK_INVALID_HANDLE;
+	CK_OBJECT_HANDLE hPrk = CK_INVALID_HANDLE;
+	rv = CRYPTOKI_F_PTR( C_GenerateKeyPair(hSession, &keyGenMech,
+		pukAttribs, sizeof(pukAttribs)/sizeof(CK_ATTRIBUTE),
+		prkAttribs, sizeof(prkAttribs)/sizeof(CK_ATTRIBUTE), &hPuk, &hPrk) );
+	CPPUNIT_ASSERT_EQUAL(CKR_OK, rv);
+
+	CK_MECHANISM wrapMech = { CKM_RSA_PKCS, NULL_PTR, 0 };
+	CK_BYTE wrapped[1024];
+	CK_ULONG wrappedLen;
+
+	CK_KEY_TYPE genericType = CKK_GENERIC_SECRET;
+	CK_OBJECT_CLASS secretClass = CKO_SECRET_KEY;
+	CK_BYTE secretValue[16] = { 0 };
+
+	// A PRIVATE secret whose label satisfies the template: must be wrappable
+	CK_ATTRIBUTE matching[] = {
+		{ CKA_CLASS, &secretClass, sizeof(secretClass) },
+		{ CKA_KEY_TYPE, &genericType, sizeof(genericType) },
+		{ CKA_LABEL, label, sizeof(label) - 1 },
+		{ CKA_VALUE, secretValue, sizeof(secretValue) },
+		{ CKA_TOKEN, &bTrue, sizeof(bTrue) },
+		{ CKA_PRIVATE, &bTrue, sizeof(bTrue) },
+		{ CKA_EXTRACTABLE, &bTrue, sizeof(bTrue) }
+	};
+	CK_OBJECT_HANDLE hMatching = CK_INVALID_HANDLE;
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, matching,
+		sizeof(matching)/sizeof(CK_ATTRIBUTE), &hMatching) );
+	CPPUNIT_ASSERT_EQUAL(CKR_OK, rv);
+
+	wrappedLen = sizeof(wrapped);
+	rv = CRYPTOKI_F_PTR( C_WrapKey(hSession, &wrapMech, hPuk, hMatching, wrapped, &wrappedLen) );
+	CPPUNIT_ASSERT_EQUAL(CKR_OK, rv);
+
+	// A PRIVATE secret whose label does not satisfy the template: must be refused
+	CK_ATTRIBUTE nonMatching[] = {
+		{ CKA_CLASS, &secretClass, sizeof(secretClass) },
+		{ CKA_KEY_TYPE, &genericType, sizeof(genericType) },
+		{ CKA_LABEL, otherLabel, sizeof(otherLabel) - 1 },
+		{ CKA_VALUE, secretValue, sizeof(secretValue) },
+		{ CKA_TOKEN, &bTrue, sizeof(bTrue) },
+		{ CKA_PRIVATE, &bTrue, sizeof(bTrue) },
+		{ CKA_EXTRACTABLE, &bTrue, sizeof(bTrue) }
+	};
+	CK_OBJECT_HANDLE hNonMatching = CK_INVALID_HANDLE;
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, nonMatching,
+		sizeof(nonMatching)/sizeof(CK_ATTRIBUTE), &hNonMatching) );
+	CPPUNIT_ASSERT_EQUAL(CKR_OK, rv);
+
+	wrappedLen = sizeof(wrapped);
+	rv = CRYPTOKI_F_PTR( C_WrapKey(hSession, &wrapMech, hPuk, hNonMatching, wrapped, &wrappedLen) );
+	CPPUNIT_ASSERT_EQUAL(CKR_KEY_NOT_WRAPPABLE, rv);
+
+	// A PRIVATE secret carrying no CKA_LABEL at all: must also be refused.
+	// The attribute defaults to an empty byte string, so this exercises the
+	// path where the key side of the comparison decrypts to nothing rather
+	// than to a differing value -- the template must still not match.
+	CK_ATTRIBUTE noLabel[] = {
+		{ CKA_CLASS, &secretClass, sizeof(secretClass) },
+		{ CKA_KEY_TYPE, &genericType, sizeof(genericType) },
+		{ CKA_VALUE, secretValue, sizeof(secretValue) },
+		{ CKA_TOKEN, &bTrue, sizeof(bTrue) },
+		{ CKA_PRIVATE, &bTrue, sizeof(bTrue) },
+		{ CKA_EXTRACTABLE, &bTrue, sizeof(bTrue) }
+	};
+	CK_OBJECT_HANDLE hNoLabel = CK_INVALID_HANDLE;
+	rv = CRYPTOKI_F_PTR( C_CreateObject(hSession, noLabel,
+		sizeof(noLabel)/sizeof(CK_ATTRIBUTE), &hNoLabel) );
+	CPPUNIT_ASSERT_EQUAL(CKR_OK, rv);
+
+	wrappedLen = sizeof(wrapped);
+	rv = CRYPTOKI_F_PTR( C_WrapKey(hSession, &wrapMech, hPuk, hNoLabel, wrapped, &wrappedLen) );
+	CPPUNIT_ASSERT_EQUAL(CKR_KEY_NOT_WRAPPABLE, rv);
+
+	CRYPTOKI_F_PTR( C_Logout(hSession) );
+	CRYPTOKI_F_PTR( C_CloseSession(hSession) );
+}

--- a/src/lib/test/AsymWrapUnwrapTests.h
+++ b/src/lib/test/AsymWrapUnwrapTests.h
@@ -41,10 +41,12 @@ class AsymWrapUnwrapTests : public TestsBase
 {
 	CPPUNIT_TEST_SUITE(AsymWrapUnwrapTests);
 	CPPUNIT_TEST(testRsaWrapUnwrap);
+	CPPUNIT_TEST(testWrapTemplatePrivateAttribute);
 	CPPUNIT_TEST_SUITE_END();
 
 public:
 	void testRsaWrapUnwrap();
+	void testWrapTemplatePrivateAttribute();
 
 protected:
 	CK_RV generateAesKey(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE &hKey);


### PR DESCRIPTION
# Developer's note

This bug was found and fixed by an LLM, while trying to run a demo on key wrapping. 
The other text sections  below were also drafted  by LLM.

I manually evaluated & found the findings to be correct, and I was able to demo a capability only with the fix applied.
I have little background on how to contribute to this repo, but I hope the fix can be applied upstream.

I am submitted the patch with no liability, warrenty or expectations assumed for myself or the maintainers.

# Fix `CKA_WRAP_TEMPLATE` enforcement for byte-string attributes

`C_WrapKey` compares each `CKA_WRAP_TEMPLATE` entry against the corresponding
attribute of the key being wrapped. For a **private** object, byte-string
attributes are stored encrypted, so the comparison puts ciphertext against the
caller's plaintext and can never match. Every template entry whose value is a
byte string — `CKA_LABEL`, `CKA_ID`, `CKA_APPLICATION` — therefore refuses
every key with `CKR_KEY_NOT_WRAPPABLE`, including a key that satisfies it
exactly.

Scalar entries are unaffected, because scalars are not encrypted at rest.

| template entry type | before | after |
|---|---|---|
| BOOL  (`CKA_EXTRACTABLE`) | ✅ enforced correctly | ✅ unchanged |
| ULONG (`CKA_CLASS`, `CKA_KEY_TYPE`) | ✅ enforced correctly | ✅ unchanged |
| BYTES (`CKA_LABEL`, `CKA_ID`) | ❌ refuses everything | ✅ enforced correctly |

The bug fails closed — it denies wrapping rather than permitting it — so this
is a correctness defect, not a vulnerability, which could be why it has gone
unnoticed. It dates to `e649c24` ("tentative C_WrapKey", 2013), the same commit
that introduced the decrypt idiom used to fix it fifteen lines further down the
same function.

## Root cause

Instrumenting `SoftHSM::C_WrapKey` to print both sides of the comparison, for a
secret key whose `CKA_LABEL` is exactly the value the template requires:

```
attr 0x3 (CKA_LABEL)
  keyVal  = D2ECA9E8DDAFF7F49FE72C3182493096EF1D43B0A764262FBA68FB51D1C16B23
  tmplVal = 617574686F72697A6564          ("authorized")
  equal=0  -> REJECT
```

The template holds the caller's value correctly. The key side does not: it
comes back as 32 bytes of AES ciphertext — a 16-byte IV plus one padded block —
rather than the plaintext label.

`C_WrapKey` reads the attribute with `key->getAttribute()`, which returns the
**raw stored** value. `C_GetAttributeValue`, and the `CKA_VALUE` path in
`C_WrapKey` itself, both call `token->decrypt()` before using such a value; the
template comparison does not.

Confirmed by flipping a single variable:

| secret's `CKA_PRIVATE` | `keyVal` | result |
|---|---|---|
| `True`  | ciphertext | BLOCK |
| `False` | `617574686F72697A6564` = `"authorized"` | ALLOW |

## Fix

Decrypt the stored value before comparing, using the same idiom the function
already applies to `CKA_VALUE`:

```cpp
if (isKeyPrivate && keyAttr.isByteStringAttribute())
{
    ByteString plain;
    if (!token->decrypt(v1, plain))
        return CKR_GENERAL_ERROR;
    v1 = plain;
}
```

`C_UnwrapKey` does **not** share the bug. `CKA_UNWRAP_TEMPLATE` is applied to
the incoming attribute list before the object exists, so nothing is encrypted
at the point of comparison. The change is scoped to `C_WrapKey`.

## Files changed

```
src/lib/SoftHSM.cpp                    the fix
src/lib/test/AsymWrapUnwrapTests.h     } testWrapTemplatePrivateAttribute,
src/lib/test/AsymWrapUnwrapTests.cpp   } one positive and two negative cases
```

The new test covers three cases against a wrapping key whose
`CKA_WRAP_TEMPLATE` requires `CKA_LABEL = "authorized"`, each using a private,
extractable generic secret:

| the key being wrapped | expected |
|---|---|
| `CKA_LABEL = "authorized"` — satisfies the template | `CKR_OK` |
| `CKA_LABEL = "unauthorized"` — differing value | `CKR_KEY_NOT_WRAPPABLE` |
| no `CKA_LABEL` at all — attribute defaults to empty | `CKR_KEY_NOT_WRAPPABLE` |

The third case matters because the fix decrypts the stored attribute before
comparing: an absent label decrypts to nothing rather than to a differing
value, and the template must still refuse it rather than error or match.

Before the fix the first case returns `CKR_KEY_NOT_WRAPPABLE` and the test
fails; after it, all three pass:

```bash
make check
```

## Reproducing without the test suite

The script below drives a built `libsofthsm2.so` through PyKCS11. Each case
gives a wrapping key a `CKA_WRAP_TEMPLATE` requiring exactly one attribute,
then wraps a secret that genuinely satisfies it — so a correct implementation
allows every case. The last case is a negative control that must be refused.

```bash
pip install PyKCS11
softhsm2-util --init-token --free --label test --so-pin 1234 --pin 1234
python3 verify_wrap_template.py --module /usr/local/lib/softhsm/libsofthsm2.so --pin 1234
```

Before the fix — the matching `CKA_LABEL` case is a false negative, and no
byte-string entry can ever match:

```
case                                   expect  actual  verdict
------------------------------------------------------------------------------
baseline: NO template                  ALLOW   ALLOW   ok
BOOL   CKA_EXTRACTABLE=True            ALLOW   ALLOW   ok
ULONG  CKA_CLASS=SECRET_KEY            ALLOW   ALLOW   ok
ULONG  CKA_KEY_TYPE=GENERIC            ALLOW   ALLOW   ok
STRING CKA_LABEL matches               ALLOW   BLOCK   *** WRONG ***  (CKR_KEY_NOT_WRAPPABLE)
STRING CKA_LABEL differs (neg ctrl)    BLOCK   BLOCK   ok  (CKR_KEY_NOT_WRAPPABLE)
```

After the fix, with the negative control still refused:

```
case                                   expect  actual  verdict
------------------------------------------------------------------------------
baseline: NO template                  ALLOW   ALLOW   ok
BOOL   CKA_EXTRACTABLE=True            ALLOW   ALLOW   ok
ULONG  CKA_CLASS=SECRET_KEY            ALLOW   ALLOW   ok
ULONG  CKA_KEY_TYPE=GENERIC            ALLOW   ALLOW   ok
STRING CKA_LABEL matches               ALLOW   ALLOW   ok
STRING CKA_LABEL differs (neg ctrl)    BLOCK   BLOCK   ok  (CKR_KEY_NOT_WRAPPABLE)
```

`verify_wrap_template.py`:

```python
#!/usr/bin/env python3
"""Which CKA_WRAP_TEMPLATE value types does SoftHSM enforce correctly?

Each case creates a wrapping key whose CKA_WRAP_TEMPLATE requires exactly ONE
attribute, then wraps a secret that genuinely satisfies it. A correct
implementation ALLOWS every case. The final case is a negative control whose
label deliberately does not match, and must be BLOCKED.
"""

import argparse
import os
import sys

import PyKCS11

DEFAULT_MODULE = "/usr/local/lib/softhsm/libsofthsm2.so"
LABEL = "authorized"
WRAP_MECH = PyKCS11.Mechanism(PyKCS11.CKM_RSA_PKCS, None)

# A wrapping key needs public-key material, but nothing here ever performs real
# RSA maths -- the template check under test happens before the mechanism runs.
# A fixed, obviously-fake modulus keeps the script dependency-free.
KEY_BYTES = 256
MODULUS = bytes([0xC0]) + os.urandom(KEY_BYTES - 2) + bytes([0x01])
EXPONENT = b"\x01\x00\x01"


def make_wrap_key(session, idx, template):
    attrs = [
        (PyKCS11.CKA_CLASS, PyKCS11.CKO_PUBLIC_KEY),
        (PyKCS11.CKA_KEY_TYPE, PyKCS11.CKK_RSA),
        (PyKCS11.CKA_TOKEN, True),
        (PyKCS11.CKA_WRAP, True),
        (PyKCS11.CKA_LABEL, "wk%d" % idx),
        (PyKCS11.CKA_MODULUS, MODULUS),
        (PyKCS11.CKA_PUBLIC_EXPONENT, EXPONENT),
    ]
    if template is not None:
        attrs.append((PyKCS11.CKA_WRAP_TEMPLATE, template))
    return session.createObject(attrs)


def make_secret(session, label):
    # CKA_PRIVATE=True is the trigger: byte-string attributes of private
    # objects are stored encrypted at rest. Set it explicitly rather than
    # relying on the default, since that is the whole point of the test.
    return session.createObject([
        (PyKCS11.CKA_CLASS, PyKCS11.CKO_SECRET_KEY),
        (PyKCS11.CKA_KEY_TYPE, PyKCS11.CKK_GENERIC_SECRET),
        (PyKCS11.CKA_LABEL, label),
        (PyKCS11.CKA_VALUE, os.urandom(32)),
        (PyKCS11.CKA_EXTRACTABLE, True),
        (PyKCS11.CKA_PRIVATE, True),
        (PyKCS11.CKA_TOKEN, True),
    ])


CASES = [
    # description, CKA_WRAP_TEMPLATE, secret's label, expected outcome
    ("baseline: NO template", None, LABEL, "ALLOW"),
    ("BOOL   CKA_EXTRACTABLE=True",
     [(PyKCS11.CKA_EXTRACTABLE, True)], LABEL, "ALLOW"),
    ("ULONG  CKA_CLASS=SECRET_KEY",
     [(PyKCS11.CKA_CLASS, PyKCS11.CKO_SECRET_KEY)], LABEL, "ALLOW"),
    ("ULONG  CKA_KEY_TYPE=GENERIC",
     [(PyKCS11.CKA_KEY_TYPE, PyKCS11.CKK_GENERIC_SECRET)], LABEL, "ALLOW"),
    ("STRING CKA_LABEL matches",
     [(PyKCS11.CKA_LABEL, LABEL)], LABEL, "ALLOW"),
    ("STRING CKA_LABEL differs (neg ctrl)",
     [(PyKCS11.CKA_LABEL, LABEL)], "unauthorized", "BLOCK"),
]


def find_slot(pkcs11, token_label):
    for slot in pkcs11.getSlotList(tokenPresent=True):
        if token_label is None:
            return slot
        if pkcs11.getTokenInfo(slot).label.strip() == token_label:
            return slot
    raise SystemExit("no token found" + (" labelled %r" % token_label if token_label else ""))


def main():
    ap = argparse.ArgumentParser(description=__doc__)
    ap.add_argument("--module", default=os.environ.get("PKCS11_MODULE", DEFAULT_MODULE),
                    help="path to libsofthsm2.so (default: %(default)s)")
    ap.add_argument("--token", default=None, help="token label (default: first token)")
    ap.add_argument("--pin", default=os.environ.get("PKCS11_PIN", "1234"),
                    help="user PIN (default: %(default)s)")
    args = ap.parse_args()

    pkcs11 = PyKCS11.PyKCS11Lib()
    pkcs11.load(args.module)
    session = pkcs11.openSession(
        find_slot(pkcs11, args.token),
        PyKCS11.CKF_RW_SESSION | PyKCS11.CKF_SERIAL_SESSION,
    )
    session.login(args.pin)

    failures = 0
    try:
        print("%-38s %-7s %-7s verdict" % ("case", "expect", "actual"))
        print("-" * 78)
        for i, (name, template, seclabel, expect) in enumerate(CASES):
            wrap_key = make_wrap_key(session, i, template)
            secret = make_secret(session, seclabel)
            try:
                session.wrapKey(wrap_key, secret, WRAP_MECH)
                actual, detail = "ALLOW", ""
            except PyKCS11.PyKCS11Error as exc:
                actual, detail = "BLOCK", "  (%s)" % exc
            ok = actual == expect
            failures += not ok
            print("%-38s %-7s %-7s %s%s"
                  % (name, expect, actual, "ok" if ok else "*** WRONG ***", detail))
    finally:
        session.logout()
        session.closeSession()

    return 1 if failures else 0


if __name__ == "__main__":
    sys.exit(main())
```

## Compatibility

Applies cleanly to 2.6.1 and 2.7.0. No API, ABI or on-disk format change: the
decryption happens in memory during the comparison, and objects written by a
patched build are byte-identical to those written by an unpatched one.

Keys that were previously refused now wrap, which is the intended correction —
a template that was silently denying everything begins enforcing what it
actually says. Anyone relying on `CKA_WRAP_TEMPLATE` as a blanket denial should
use `CKA_WRAP=CK_FALSE` instead.

## A note on the documentation

The documentation states that `CKA_WRAP_TEMPLATE` is "not supported due to
[its] complexity". That is only partly true of the code as shipped: the
enforcement logic in `C_WrapKey` is present and works for scalar-valued
entries. Only byte-string entries were broken, and only because of the
encrypted-at-rest comparison above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed key wrapping with attribute-based templates for private objects.
  - Matching byte-string attributes are now recognized correctly, allowing authorized objects to be wrapped.
  - Objects with mismatched or missing attributes continue to be rejected as not wrappable.
  - Decryption failures during attribute verification now return an appropriate error instead of proceeding.

- **Tests**
  - Added coverage for successful and rejected wrapping scenarios involving private object attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->