### PR TITLE
Add ChaCha20-Poly1305 support

### DIFF
--- a/src/lib/P11Objects.cpp
+++ b/src/lib/P11Objects.cpp
@@ -1947,6 +1947,44 @@ bool P11GOSTSecretKeyObj::init(OSObject *inobject)
 }
 
 // Constructor
+P11ChaCha20SecretKeyObj::P11ChaCha20SecretKeyObj()
+{
+	initialized = false;
+}
+
+// Add attributes
+bool P11ChaCha20SecretKeyObj::init(OSObject *inobject)
+{
+	if (initialized) return true;
+	if (inobject == NULL) return false;
+
+	if (!inobject->attributeExists(CKA_KEY_TYPE) || inobject->getUnsignedLongValue(CKA_KEY_TYPE, CKK_VENDOR_DEFINED) != CKK_CHACHA20) {
+		OSAttribute setKeyType((unsigned long)CKK_CHACHA20);
+		inobject->setAttribute(CKA_KEY_TYPE, setKeyType);
+	}
+
+	// Create parent
+	if (!P11SecretKeyObj::init(inobject)) return false;
+
+	// ChaCha20 keys always have a fixed 256-bit length; no CKA_VALUE_LEN
+	P11Attribute* attrValue = new P11AttrValue(osobject,P11Attribute::ck1|P11Attribute::ck4|P11Attribute::ck6|P11Attribute::ck7);
+
+	// Initialize the attributes
+	if (!attrValue->init())
+	{
+		ERROR_MSG("Could not initialize the attribute");
+		delete attrValue;
+		return false;
+	}
+
+	// Add them to the map
+	attributes[attrValue->getType()] = attrValue;
+
+	initialized = true;
+	return true;
+}
+
+// Constructor
 P11DomainObj::P11DomainObj()
 {
 	initialized = false;

--- a/src/lib/P11Objects.h
+++ b/src/lib/P11Objects.h
@@ -438,6 +438,19 @@ protected:
 	bool initialized;
 };
 
+class P11ChaCha20SecretKeyObj : public P11SecretKeyObj
+{
+public:
+	// Constructor
+	P11ChaCha20SecretKeyObj();
+
+	// Add attributes
+	virtual bool init(OSObject *inobject);
+
+protected:
+	bool initialized;
+};
+
 class P11DomainObj : public P11Object
 {
 protected:

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -2626,18 +2626,36 @@ CK_RV SoftHSM::SymEncryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMech
 				DEBUG_MSG("ChaCha20-Poly1305 requires parameters");
 				return CKR_ARGUMENTS_BAD;
 			}
+#if defined(WITH_OPENSSL)
+			// The OpenSSL backend's ChaCha20-Poly1305 IV length is fixed at
+			// 96 bits; other lengths are silently truncated/over-read by EVP.
+			if (CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits != 96)
+#else
 			if (CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits == 0 ||
 			    CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits % 8 != 0 ||
 			    CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits > 192)
+#endif
 			{
 				DEBUG_MSG("Invalid ulNonceBits");
 				return CKR_MECHANISM_PARAM_INVALID;
+			}
+			if (CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->pNonce == NULL_PTR)
+			{
+				DEBUG_MSG("ChaCha20-Poly1305 requires a nonce");
+				return CKR_ARGUMENTS_BAD;
 			}
 			iv.resize(CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits / 8);
 			memcpy(&iv[0], CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->pNonce, iv.size());
 			aad.resize(CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulAADLen);
 			if (aad.size() > 0)
+			{
+				if (CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->pAAD == NULL_PTR)
+				{
+					DEBUG_MSG("Invalid AAD parameter");
+					return CKR_ARGUMENTS_BAD;
+				}
 				memcpy(&aad[0], CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->pAAD, aad.size());
+			}
 			tagBytes = 16;
 			break;
 		default:
@@ -3407,18 +3425,36 @@ CK_RV SoftHSM::SymDecryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMech
 				DEBUG_MSG("ChaCha20-Poly1305 requires parameters");
 				return CKR_ARGUMENTS_BAD;
 			}
+#if defined(WITH_OPENSSL)
+			// The OpenSSL backend's ChaCha20-Poly1305 IV length is fixed at
+			// 96 bits; other lengths are silently truncated/over-read by EVP.
+			if (CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits != 96)
+#else
 			if (CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits == 0 ||
 			    CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits % 8 != 0 ||
 			    CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits > 192)
+#endif
 			{
 				DEBUG_MSG("Invalid ulNonceBits");
 				return CKR_MECHANISM_PARAM_INVALID;
+			}
+			if (CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->pNonce == NULL_PTR)
+			{
+				DEBUG_MSG("ChaCha20-Poly1305 requires a nonce");
+				return CKR_ARGUMENTS_BAD;
 			}
 			iv.resize(CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits / 8);
 			memcpy(&iv[0], CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->pNonce, iv.size());
 			aad.resize(CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulAADLen);
 			if (aad.size() > 0)
+			{
+				if (CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->pAAD == NULL_PTR)
+				{
+					DEBUG_MSG("Invalid AAD parameter");
+					return CKR_ARGUMENTS_BAD;
+				}
 				memcpy(&aad[0], CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->pAAD, aad.size());
+			}
 			tagBytes = 16;
 			break;
 		default:
@@ -10011,8 +10047,8 @@ CK_RV SoftHSM::generateChaCha20
 			ByteString kcv;
 			if (isPrivate)
 			{
-				token->encrypt(key->getKeyBits(), value);
-				token->encrypt(key->getKeyCheckValue(), kcv);
+				bOK = bOK && token->encrypt(key->getKeyBits(), value);
+				bOK = bOK && token->encrypt(key->getKeyCheckValue(), kcv);
 			}
 			else
 			{

--- a/src/lib/SoftHSM.cpp
+++ b/src/lib/SoftHSM.cpp
@@ -223,6 +223,10 @@ static CK_RV newP11Object(CK_OBJECT_CLASS objClass, CK_KEY_TYPE keyType, CK_CERT
 			{
 				*p11object = new P11GOSTSecretKeyObj();
 			}
+			else if (keyType == CKK_CHACHA20)
+			{
+				*p11object = new P11ChaCha20SecretKeyObj();
+			}
 			else
 				return CKR_ATTRIBUTE_VALUE_INVALID;
 			break;
@@ -860,6 +864,8 @@ void SoftHSM::prepareSupportedMechanisms(std::map<std::string, CK_MECHANISM_TYPE
 	t["CKM_AES_ECB_ENCRYPT_DATA"]	= CKM_AES_ECB_ENCRYPT_DATA;
 	t["CKM_AES_CBC_ENCRYPT_DATA"]	= CKM_AES_CBC_ENCRYPT_DATA;
 	t["CKM_AES_CMAC"]		= CKM_AES_CMAC;
+	t["CKM_CHACHA20_KEY_GEN"]	= CKM_CHACHA20_KEY_GEN;
+	t["CKM_CHACHA20_POLY1305"]	= CKM_CHACHA20_POLY1305;
 	t["CKM_DSA_PARAMETER_GEN"]	= CKM_DSA_PARAMETER_GEN;
 	t["CKM_DSA_KEY_PAIR_GEN"]	= CKM_DSA_KEY_PAIR_GEN;
 	t["CKM_DSA"]			= CKM_DSA;
@@ -1336,6 +1342,16 @@ CK_RV SoftHSM::C_GetMechanismInfo(CK_SLOT_ID slotID, CK_MECHANISM_TYPE type, CK_
 			pInfo->ulMinKeySize = 16;
 			pInfo->ulMaxKeySize = 32;
 			pInfo->flags |= CKF_ENCRYPT | CKF_DECRYPT;
+			break;
+		case CKM_CHACHA20_KEY_GEN:
+			pInfo->ulMinKeySize = 32;
+			pInfo->ulMaxKeySize = 32;
+			pInfo->flags = CKF_GENERATE;
+			break;
+		case CKM_CHACHA20_POLY1305:
+			pInfo->ulMinKeySize = 32;
+			pInfo->ulMaxKeySize = 32;
+			pInfo->flags = CKF_ENCRYPT | CKF_DECRYPT;
 			break;
 		case CKM_AES_KEY_WRAP:
 			pInfo->ulMinKeySize = 16;
@@ -2379,6 +2395,7 @@ static bool isSymMechanism(CK_MECHANISM_PTR pMechanism)
 		case CKM_AES_CBC_PAD:
 		case CKM_AES_CTR:
 		case CKM_AES_GCM:
+		case CKM_CHACHA20_POLY1305:
 			return true;
 		default:
 			return false;
@@ -2597,6 +2614,31 @@ CK_RV SoftHSM::SymEncryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMech
 				return CKR_ARGUMENTS_BAD;
 			}
 			tagBytes = tagBytes / 8;
+			break;
+		case CKM_CHACHA20_POLY1305:
+			if (keyType != CKK_CHACHA20)
+				return CKR_KEY_TYPE_INCONSISTENT;
+			algo = SymAlgo::ChaCha20Poly1305;
+			mode = SymMode::ChaCha20Poly1305;
+			if (pMechanism->pParameter == NULL_PTR ||
+			    pMechanism->ulParameterLen != sizeof(CK_SALSA20_CHACHA20_POLY1305_PARAMS))
+			{
+				DEBUG_MSG("ChaCha20-Poly1305 requires parameters");
+				return CKR_ARGUMENTS_BAD;
+			}
+			if (CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits == 0 ||
+			    CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits % 8 != 0 ||
+			    CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits > 192)
+			{
+				DEBUG_MSG("Invalid ulNonceBits");
+				return CKR_MECHANISM_PARAM_INVALID;
+			}
+			iv.resize(CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits / 8);
+			memcpy(&iv[0], CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->pNonce, iv.size());
+			aad.resize(CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulAADLen);
+			if (aad.size() > 0)
+				memcpy(&aad[0], CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->pAAD, aad.size());
+			tagBytes = 16;
 			break;
 		default:
 			return CKR_MECHANISM_INVALID;
@@ -3353,6 +3395,31 @@ CK_RV SoftHSM::SymDecryptInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMech
 				return CKR_ARGUMENTS_BAD;
 			}
 			tagBytes = tagBytes / 8;
+			break;
+		case CKM_CHACHA20_POLY1305:
+			if (keyType != CKK_CHACHA20)
+				return CKR_KEY_TYPE_INCONSISTENT;
+			algo = SymAlgo::ChaCha20Poly1305;
+			mode = SymMode::ChaCha20Poly1305;
+			if (pMechanism->pParameter == NULL_PTR ||
+			    pMechanism->ulParameterLen != sizeof(CK_SALSA20_CHACHA20_POLY1305_PARAMS))
+			{
+				DEBUG_MSG("ChaCha20-Poly1305 requires parameters");
+				return CKR_ARGUMENTS_BAD;
+			}
+			if (CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits == 0 ||
+			    CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits % 8 != 0 ||
+			    CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits > 192)
+			{
+				DEBUG_MSG("Invalid ulNonceBits");
+				return CKR_MECHANISM_PARAM_INVALID;
+			}
+			iv.resize(CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulNonceBits / 8);
+			memcpy(&iv[0], CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->pNonce, iv.size());
+			aad.resize(CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->ulAADLen);
+			if (aad.size() > 0)
+				memcpy(&aad[0], CK_SALSA20_CHACHA20_POLY1305_PARAMS_PTR(pMechanism->pParameter)->pAAD, aad.size());
+			tagBytes = 16;
 			break;
 		default:
 			return CKR_MECHANISM_INVALID;
@@ -6786,6 +6853,10 @@ CK_RV SoftHSM::C_GenerateKey(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMecha
 			objClass = CKO_SECRET_KEY;
 			keyType = CKK_AES;
 			break;
+		case CKM_CHACHA20_KEY_GEN:
+			objClass = CKO_SECRET_KEY;
+			keyType = CKK_CHACHA20;
+			break;
 		case CKM_GENERIC_SECRET_KEY_GEN:
 			objClass = CKO_SECRET_KEY;
 			keyType = CKK_GENERIC_SECRET;
@@ -6821,6 +6892,9 @@ CK_RV SoftHSM::C_GenerateKey(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMecha
 		return CKR_TEMPLATE_INCONSISTENT;
 	if (pMechanism->mechanism == CKM_AES_KEY_GEN &&
 	    (objClass != CKO_SECRET_KEY || keyType != CKK_AES))
+		return CKR_TEMPLATE_INCONSISTENT;
+	if (pMechanism->mechanism == CKM_CHACHA20_KEY_GEN &&
+	    (objClass != CKO_SECRET_KEY || keyType != CKK_CHACHA20))
 		return CKR_TEMPLATE_INCONSISTENT;
 	if (pMechanism->mechanism == CKM_GENERIC_SECRET_KEY_GEN &&
 	    (objClass != CKO_SECRET_KEY || keyType != CKK_GENERIC_SECRET))
@@ -6872,6 +6946,12 @@ CK_RV SoftHSM::C_GenerateKey(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMecha
 	if (pMechanism->mechanism == CKM_AES_KEY_GEN)
 	{
 		return this->generateAES(hSession, pTemplate, ulCount, phKey, isOnToken, isPrivate);
+	}
+
+	// Generate ChaCha20 secret key
+	if (pMechanism->mechanism == CKM_CHACHA20_KEY_GEN)
+	{
+		return this->generateChaCha20(hSession, pTemplate, ulCount, phKey, isOnToken, isPrivate);
 	}
 
 	// Generate generic secret key
@@ -9790,6 +9870,173 @@ CK_RV SoftHSM::generateAES
 	// Clean up
 	aes->recycleKey(key);
 	CryptoFactory::i()->recycleSymmetricAlgorithm(aes);
+
+	// Remove the key that may have been created already when the function fails.
+	if (rv != CKR_OK)
+	{
+		if (*phKey != CK_INVALID_HANDLE)
+		{
+			OSObject* oskey = (OSObject*)handleManager->getObject(*phKey);
+			handleManager->destroyObject(*phKey);
+			if (oskey) oskey->destroyObject();
+			*phKey = CK_INVALID_HANDLE;
+		}
+	}
+
+	return rv;
+}
+
+// Generate a ChaCha20 secret key
+CK_RV SoftHSM::generateChaCha20
+(CK_SESSION_HANDLE hSession,
+	CK_ATTRIBUTE_PTR pTemplate,
+	CK_ULONG ulCount,
+	CK_OBJECT_HANDLE_PTR phKey,
+	CK_BBOOL isOnToken,
+	CK_BBOOL isPrivate)
+{
+	*phKey = CK_INVALID_HANDLE;
+
+	// Get the session
+	Session* session = (Session*)handleManager->getSession(hSession);
+	if (session == NULL)
+		return CKR_SESSION_HANDLE_INVALID;
+
+	// Get the token
+	Token* token = session->getToken();
+	if (token == NULL)
+		return CKR_GENERAL_ERROR;
+
+	// Extract desired parameter information
+	bool checkValue = true;
+	for (CK_ULONG i = 0; i < ulCount; i++)
+	{
+		switch (pTemplate[i].type)
+		{
+			case CKA_CHECK_VALUE:
+				if (pTemplate[i].ulValueLen > 0)
+				{
+					INFO_MSG("CKA_CHECK_VALUE must be a no-value (0 length) entry");
+					return CKR_ATTRIBUTE_VALUE_INVALID;
+				}
+				checkValue = false;
+				break;
+			default:
+				break;
+		}
+	}
+
+	// Generate the secret key; ChaCha20-Poly1305 always uses a 256-bit key
+	SymmetricKey* key = new SymmetricKey(256);
+	SymmetricAlgorithm* chacha20 = CryptoFactory::i()->getSymmetricAlgorithm(SymAlgo::ChaCha20Poly1305);
+	if (chacha20 == NULL)
+	{
+		ERROR_MSG("Could not get SymmetricAlgorithm");
+		delete key;
+		return CKR_GENERAL_ERROR;
+	}
+	RNG* rng = CryptoFactory::i()->getRNG();
+	if (rng == NULL)
+	{
+		ERROR_MSG("Could not get RNG");
+		chacha20->recycleKey(key);
+		CryptoFactory::i()->recycleSymmetricAlgorithm(chacha20);
+		return CKR_GENERAL_ERROR;
+	}
+	if (!chacha20->generateKey(*key, rng))
+	{
+		ERROR_MSG("Could not generate ChaCha20 secret key");
+		chacha20->recycleKey(key);
+		CryptoFactory::i()->recycleSymmetricAlgorithm(chacha20);
+		return CKR_GENERAL_ERROR;
+	}
+
+	CK_RV rv = CKR_OK;
+
+	// Create the secret key object using C_CreateObject
+	const CK_ULONG maxAttribs = 32;
+	CK_OBJECT_CLASS objClass = CKO_SECRET_KEY;
+	CK_KEY_TYPE keyType = CKK_CHACHA20;
+	CK_ATTRIBUTE keyAttribs[maxAttribs] = {
+		{ CKA_CLASS, &objClass, sizeof(objClass) },
+		{ CKA_TOKEN, &isOnToken, sizeof(isOnToken) },
+		{ CKA_PRIVATE, &isPrivate, sizeof(isPrivate) },
+		{ CKA_KEY_TYPE, &keyType, sizeof(keyType) },
+	};
+	CK_ULONG keyAttribsCount = 4;
+
+	// Add the additional
+	if (ulCount > (maxAttribs - keyAttribsCount))
+		rv = CKR_TEMPLATE_INCONSISTENT;
+	for (CK_ULONG i=0; i < ulCount && rv == CKR_OK; ++i)
+	{
+		switch (pTemplate[i].type)
+		{
+			case CKA_CLASS:
+			case CKA_TOKEN:
+			case CKA_PRIVATE:
+			case CKA_KEY_TYPE:
+			case CKA_CHECK_VALUE:
+				continue;
+		default:
+			keyAttribs[keyAttribsCount++] = pTemplate[i];
+		}
+	}
+
+	if (rv == CKR_OK)
+		rv = this->CreateObject(hSession, keyAttribs, keyAttribsCount, phKey, OBJECT_OP_GENERATE);
+
+	// Store the attributes that are being supplied
+	if (rv == CKR_OK)
+	{
+		OSObject* osobject = (OSObject*)handleManager->getObject(*phKey);
+		if (osobject == NULL_PTR || !osobject->isValid()) {
+			rv = CKR_FUNCTION_FAILED;
+		} else if (osobject->startTransaction()) {
+			bool bOK = true;
+
+			// Common Attributes
+			bOK = bOK && osobject->setAttribute(CKA_LOCAL,true);
+			CK_ULONG ulKeyGenMechanism = (CK_ULONG)CKM_CHACHA20_KEY_GEN;
+			bOK = bOK && osobject->setAttribute(CKA_KEY_GEN_MECHANISM,ulKeyGenMechanism);
+
+			// Common Secret Key Attributes
+			bool bAlwaysSensitive = osobject->getBooleanValue(CKA_SENSITIVE, false);
+			bOK = bOK && osobject->setAttribute(CKA_ALWAYS_SENSITIVE,bAlwaysSensitive);
+			bool bNeverExtractable = osobject->getBooleanValue(CKA_EXTRACTABLE, false) == false;
+			bOK = bOK && osobject->setAttribute(CKA_NEVER_EXTRACTABLE, bNeverExtractable);
+
+			// ChaCha20 Secret Key Attributes
+			ByteString value;
+			ByteString kcv;
+			if (isPrivate)
+			{
+				token->encrypt(key->getKeyBits(), value);
+				token->encrypt(key->getKeyCheckValue(), kcv);
+			}
+			else
+			{
+				value = key->getKeyBits();
+				kcv = key->getKeyCheckValue();
+			}
+			bOK = bOK && osobject->setAttribute(CKA_VALUE, value);
+			if (checkValue)
+				bOK = bOK && osobject->setAttribute(CKA_CHECK_VALUE, kcv);
+
+			if (bOK)
+				bOK = osobject->commitTransaction();
+			else
+				osobject->abortTransaction();
+
+			if (!bOK)
+				rv = CKR_FUNCTION_FAILED;
+		} else
+			rv = CKR_FUNCTION_FAILED;
+	}
+
+	// Clean up
+	chacha20->recycleKey(key);
+	CryptoFactory::i()->recycleSymmetricAlgorithm(chacha20);
 
 	// Remove the key that may have been created already when the function fails.
 	if (rv != CKR_OK)

--- a/src/lib/SoftHSM.h
+++ b/src/lib/SoftHSM.h
@@ -274,6 +274,15 @@ private:
 		CK_BBOOL isOnToken,
 		CK_BBOOL isPrivate
 	);
+	CK_RV generateChaCha20
+	(
+		CK_SESSION_HANDLE hSession,
+		CK_ATTRIBUTE_PTR pTemplate,
+		CK_ULONG ulCount,
+		CK_OBJECT_HANDLE_PTR phKey,
+		CK_BBOOL isOnToken,
+		CK_BBOOL isPrivate
+	);
 	CK_RV generateRSA
 	(CK_SESSION_HANDLE hSession,
 		CK_ATTRIBUTE_PTR pPublicKeyTemplate,

--- a/src/lib/crypto/BotanChaCha20Poly1305.cpp
+++ b/src/lib/crypto/BotanChaCha20Poly1305.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+/*****************************************************************************
+ BotanChaCha20Poly1305.cpp
+
+ Botan ChaCha20-Poly1305 implementation
+ *****************************************************************************/
+
+#include "config.h"
+#include "BotanChaCha20Poly1305.h"
+
+std::string BotanChaCha20Poly1305::getCipher() const
+{
+	if (currentKey == NULL) return "";
+
+	// ChaCha20-Poly1305 requires a 256-bit key
+	if (currentKey->getBitLen() != 256)
+	{
+		ERROR_MSG("Invalid ChaCha20-Poly1305 currentKey length (%d bits)", currentKey->getBitLen());
+
+		return "";
+	}
+
+	if (currentCipherMode != SymMode::ChaCha20Poly1305)
+	{
+		ERROR_MSG("Invalid ChaCha20-Poly1305 cipher mode %i", currentCipherMode);
+
+		return "";
+	}
+
+	return "ChaCha20Poly1305";
+}
+
+size_t BotanChaCha20Poly1305::getBlockSize() const
+{
+	// ChaCha20-Poly1305 is a stream cipher
+	return 1;
+}

--- a/src/lib/crypto/BotanChaCha20Poly1305.h
+++ b/src/lib/crypto/BotanChaCha20Poly1305.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+/*****************************************************************************
+ BotanChaCha20Poly1305.h
+
+ Botan ChaCha20-Poly1305 implementation
+ *****************************************************************************/
+
+#ifndef _SOFTHSM_V2_BOTANCHACHA20POLY1305_H
+#define _SOFTHSM_V2_BOTANCHACHA20POLY1305_H
+
+#include <string>
+#include "config.h"
+#include "BotanSymmetricAlgorithm.h"
+
+class BotanChaCha20Poly1305 : public BotanSymmetricAlgorithm
+{
+public:
+	// Destructor
+	virtual ~BotanChaCha20Poly1305() { }
+
+	virtual bool wrapKey(const SymmetricKey* /*key*/, const SymWrap::Type /*mode*/, const ByteString& /*in*/, ByteString& /*out*/) { return false; }
+	virtual bool unwrapKey(const SymmetricKey* /*key*/, const SymWrap::Type /*mode*/, const ByteString& /*in*/, ByteString& /*out*/) { return false; }
+
+	// Return the block size
+	virtual size_t getBlockSize() const;
+
+protected:
+	// Return the right Botan cipher for the operation
+	virtual std::string getCipher() const;
+};
+
+#endif // !_SOFTHSM_V2_BOTANCHACHA20POLY1305_H

--- a/src/lib/crypto/BotanCryptoFactory.cpp
+++ b/src/lib/crypto/BotanCryptoFactory.cpp
@@ -33,6 +33,7 @@
 #include "config.h"
 #include "BotanCryptoFactory.h"
 #include "BotanAES.h"
+#include "BotanChaCha20Poly1305.h"
 #include "BotanDES.h"
 #include "BotanDSA.h"
 #include "BotanDH.h"
@@ -119,6 +120,8 @@ SymmetricAlgorithm* BotanCryptoFactory::getSymmetricAlgorithm(SymAlgo::Type algo
 		case SymAlgo::DES:
 		case SymAlgo::DES3:
 	                return new BotanDES();
+		case SymAlgo::ChaCha20Poly1305:
+			return new BotanChaCha20Poly1305();
 		default:
 	                // No algorithm implementation is available
         	        ERROR_MSG("Unknown algorithm '%i'", algorithm);

--- a/src/lib/crypto/BotanSymmetricAlgorithm.cpp
+++ b/src/lib/crypto/BotanSymmetricAlgorithm.cpp
@@ -101,7 +101,7 @@ bool BotanSymmetricAlgorithm::encryptInit(const SymmetricKey* key, const SymMode
 	}
 
 	// Check the IV
-	if (mode != SymMode::GCM && (IV.size() > 0) && (IV.size() != getBlockSize()))
+	if (mode != SymMode::GCM && mode != SymMode::ChaCha20Poly1305 && (IV.size() > 0) && (IV.size() != getBlockSize()))
 	{
 		ERROR_MSG("Invalid IV size (%d bytes, expected %d bytes)", IV.size(), getBlockSize());
 
@@ -188,7 +188,7 @@ bool BotanSymmetricAlgorithm::encryptInit(const SymmetricKey* key, const SymMode
 			cipher->set_key(botanKey);
 			cryption = new Botan::Pipe(cipher);
 		}
-		else if (mode == SymMode::GCM)
+		else if (mode == SymMode::GCM || mode == SymMode::ChaCha20Poly1305)
 		{
 			Botan::AEAD_Mode* aead = Botan::get_aead(cipherName, Botan::ENCRYPTION);
 			aead->set_key(botanKey);
@@ -336,7 +336,7 @@ bool BotanSymmetricAlgorithm::decryptInit(const SymmetricKey* key, const SymMode
 	}
 
 	// Check the IV
-	if (mode != SymMode::GCM && (IV.size() > 0) && (IV.size() != getBlockSize()))
+	if (mode != SymMode::GCM && mode != SymMode::ChaCha20Poly1305 && (IV.size() > 0) && (IV.size() != getBlockSize()))
 	{
 		ERROR_MSG("Invalid IV size (%d bytes, expected %d bytes)", IV.size(), getBlockSize());
 
@@ -423,7 +423,7 @@ bool BotanSymmetricAlgorithm::decryptInit(const SymmetricKey* key, const SymMode
 			cipher->set_key(botanKey);
 			cryption = new Botan::Pipe(cipher);
 		}
-		else if (mode == SymMode::GCM)
+		else if (mode == SymMode::GCM || mode == SymMode::ChaCha20Poly1305)
 		{
 			Botan::AEAD_Mode* aead = Botan::get_aead(cipherName, Botan::DECRYPTION);
 			aead->set_key(botanKey);
@@ -468,7 +468,7 @@ bool BotanSymmetricAlgorithm::decryptUpdate(const ByteString& encryptedData, Byt
 	}
 
 	// AEAD ciphers should not return decrypted data until final is called
-	if (currentCipherMode == SymMode::GCM)
+	if (currentCipherMode == SymMode::GCM || currentCipherMode == SymMode::ChaCha20Poly1305)
 	{
 		data.resize(0);
 		return true;
@@ -541,7 +541,7 @@ bool BotanSymmetricAlgorithm::decryptFinal(ByteString& data)
 		return false;
 	}
 
-	if (mode == SymMode::GCM)
+	if (mode == SymMode::GCM || mode == SymMode::ChaCha20Poly1305)
 	{
 		// Write data
 		try

--- a/src/lib/crypto/CMakeLists.txt
+++ b/src/lib/crypto/CMakeLists.txt
@@ -50,6 +50,7 @@ set(SOURCES AESKey.cpp
 
 if(WITH_OPENSSL)
     list(APPEND SOURCES OSSLAES.cpp
+                        OSSLChaCha20Poly1305.cpp
                         OSSLCMAC.cpp
                         OSSLComp.cpp
                         OSSLCryptoFactory.cpp
@@ -110,6 +111,7 @@ endif(WITH_OPENSSL)
 
 if(WITH_BOTAN)
     list(APPEND SOURCES BotanAES.cpp
+                        BotanChaCha20Poly1305.cpp
                         BotanCryptoFactory.cpp
                         BotanDES.cpp
                         BotanDH.cpp

--- a/src/lib/crypto/Makefile.am
+++ b/src/lib/crypto/Makefile.am
@@ -57,6 +57,7 @@ EXTRA_DIST =			$(srcdir)/CMakeLists.txt \
 # Compile with support of OpenSSL
 if WITH_OPENSSL
 libsofthsm_crypto_la_SOURCES +=	OSSLAES.cpp \
+				OSSLChaCha20Poly1305.cpp \
 				OSSLComp.cpp \
 				OSSLCryptoFactory.cpp \
 				OSSLDES.cpp \
@@ -117,6 +118,7 @@ endif
 # Compile with support of Botan
 if WITH_BOTAN
 libsofthsm_crypto_la_SOURCES +=	BotanAES.cpp \
+				BotanChaCha20Poly1305.cpp \
 				BotanCryptoFactory.cpp \
 				BotanDES.cpp \
 				BotanDH.cpp \

--- a/src/lib/crypto/OSSLChaCha20Poly1305.cpp
+++ b/src/lib/crypto/OSSLChaCha20Poly1305.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+/*****************************************************************************
+ OSSLChaCha20Poly1305.cpp
+
+ OpenSSL ChaCha20-Poly1305 implementation
+ *****************************************************************************/
+
+#include "config.h"
+#include "OSSLChaCha20Poly1305.h"
+
+const EVP_CIPHER* OSSLChaCha20Poly1305::getCipher() const
+{
+	if (currentCipherMode != SymMode::ChaCha20Poly1305)
+	{
+		ERROR_MSG("Invalid cipher mode %i for ChaCha20-Poly1305", currentCipherMode);
+		return NULL;
+	}
+
+	// ChaCha20-Poly1305 requires a 256-bit key
+	if (currentKey == NULL || currentKey->getBitLen() != 256)
+	{
+		ERROR_MSG("ChaCha20-Poly1305 requires a 256-bit key");
+		return NULL;
+	}
+
+	return EVP_chacha20_poly1305();
+}

--- a/src/lib/crypto/OSSLChaCha20Poly1305.h
+++ b/src/lib/crypto/OSSLChaCha20Poly1305.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 SoftHSMv2 contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+/*****************************************************************************
+ OSSLChaCha20Poly1305.h
+
+ OpenSSL ChaCha20-Poly1305 implementation
+ *****************************************************************************/
+
+#ifndef _SOFTHSM_V2_OSSLCHACHA20POLY1305_H
+#define _SOFTHSM_V2_OSSLCHACHA20POLY1305_H
+
+#include <openssl/evp.h>
+#include "config.h"
+#include "OSSLEVPSymmetricAlgorithm.h"
+
+class OSSLChaCha20Poly1305 : public OSSLEVPSymmetricAlgorithm
+{
+public:
+	virtual ~OSSLChaCha20Poly1305() { }
+
+	virtual bool wrapKey(const SymmetricKey* /*key*/, const SymWrap::Type /*mode*/, const ByteString& /*in*/, ByteString& /*out*/) { return false; }
+	virtual bool unwrapKey(const SymmetricKey* /*key*/, const SymWrap::Type /*mode*/, const ByteString& /*in*/, ByteString& /*out*/) { return false; }
+
+	virtual size_t getBlockSize() const { return 1; }
+
+protected:
+	virtual const EVP_CIPHER* getCipher() const;
+};
+
+#endif // !_SOFTHSM_V2_OSSLCHACHA20POLY1305_H

--- a/src/lib/crypto/OSSLCryptoFactory.cpp
+++ b/src/lib/crypto/OSSLCryptoFactory.cpp
@@ -35,6 +35,7 @@
 #include "OSSLCryptoFactory.h"
 #include "OSSLRNG.h"
 #include "OSSLAES.h"
+#include "OSSLChaCha20Poly1305.h"
 #include "OSSLDES.h"
 #include "OSSLMD5.h"
 #include "OSSLSHA1.h"
@@ -328,6 +329,8 @@ SymmetricAlgorithm* OSSLCryptoFactory::getSymmetricAlgorithm(SymAlgo::Type algor
 	{
 		case SymAlgo::AES:
 			return new OSSLAES();
+		case SymAlgo::ChaCha20Poly1305:
+			return new OSSLChaCha20Poly1305();
 		case SymAlgo::DES:
 		case SymAlgo::DES3:
 			return new OSSLDES();

--- a/src/lib/crypto/OSSLEVPSymmetricAlgorithm.cpp
+++ b/src/lib/crypto/OSSLEVPSymmetricAlgorithm.cpp
@@ -116,7 +116,7 @@ bool OSSLEVPSymmetricAlgorithm::encryptInit(const SymmetricKey* key, const SymMo
 	}
 
 	// Check the IV
-	if (mode != SymMode::GCM && (IV.size() > 0) && (IV.size() != getBlockSize()))
+	if (mode != SymMode::GCM && mode != SymMode::ChaCha20Poly1305 && (IV.size() > 0) && (IV.size() != getBlockSize()))
 	{
 		ERROR_MSG("Invalid IV size (%d bytes, expected %d bytes)", IV.size(), getBlockSize());
 
@@ -166,13 +166,13 @@ bool OSSLEVPSymmetricAlgorithm::encryptInit(const SymmetricKey* key, const SymMo
 	}
 
 	int rv;
-	if (mode == SymMode::GCM)
+	if (mode == SymMode::GCM || mode == SymMode::ChaCha20Poly1305)
 	{
 		rv = EVP_EncryptInit_ex(pCurCTX, cipher, NULL, NULL, NULL);
 
 		if (rv)
 		{
-			EVP_CIPHER_CTX_ctrl(pCurCTX, EVP_CTRL_GCM_SET_IVLEN, iv.size(), NULL);
+			EVP_CIPHER_CTX_ctrl(pCurCTX, EVP_CTRL_AEAD_SET_IVLEN, iv.size(), NULL);
 			rv = EVP_EncryptInit_ex(pCurCTX, NULL, NULL, (unsigned char*) currentKey->getKeyBits().const_byte_str(), iv.byte_str());
 		}
 	}
@@ -195,7 +195,7 @@ bool OSSLEVPSymmetricAlgorithm::encryptInit(const SymmetricKey* key, const SymMo
 
 	EVP_CIPHER_CTX_set_padding(pCurCTX, padding ? 1 : 0);
 
-	if (mode == SymMode::GCM)
+	if (mode == SymMode::GCM || mode == SymMode::ChaCha20Poly1305)
 	{
 		int outLen = 0;
 		if (aad.size() && !EVP_EncryptUpdate(pCurCTX, NULL, &outLen, (unsigned char*) aad.const_byte_str(), aad.size()))
@@ -286,11 +286,11 @@ bool OSSLEVPSymmetricAlgorithm::encryptFinal(ByteString& encryptedData)
 	// Resize the output block
 	encryptedData.resize(outLen);
 
-	if (mode == SymMode::GCM)
+	if (mode == SymMode::GCM || mode == SymMode::ChaCha20Poly1305)
 	{
 		ByteString tag;
 		tag.resize(tagBytes);
-		EVP_CIPHER_CTX_ctrl(pCurCTX, EVP_CTRL_GCM_GET_TAG, tagBytes, &tag[0]);
+		EVP_CIPHER_CTX_ctrl(pCurCTX, EVP_CTRL_AEAD_GET_TAG, tagBytes, &tag[0]);
 		encryptedData += tag;
 	}
 
@@ -309,7 +309,7 @@ bool OSSLEVPSymmetricAlgorithm::decryptInit(const SymmetricKey* key, const SymMo
 	}
 
 	// Check the IV
-	if (mode != SymMode::GCM && (IV.size() > 0) && (IV.size() != getBlockSize()))
+	if (mode != SymMode::GCM && mode != SymMode::ChaCha20Poly1305 && (IV.size() > 0) && (IV.size() != getBlockSize()))
 	{
 		ERROR_MSG("Invalid IV size (%d bytes, expected %d bytes)", IV.size(), getBlockSize());
 
@@ -359,13 +359,13 @@ bool OSSLEVPSymmetricAlgorithm::decryptInit(const SymmetricKey* key, const SymMo
 	}
 
 	int rv;
-	if (mode == SymMode::GCM)
+	if (mode == SymMode::GCM || mode == SymMode::ChaCha20Poly1305)
 	{
 		rv = EVP_DecryptInit_ex(pCurCTX, cipher, NULL, NULL, NULL);
 
 		if (rv)
 		{
-			EVP_CIPHER_CTX_ctrl(pCurCTX, EVP_CTRL_GCM_SET_IVLEN, iv.size(), NULL);
+			EVP_CIPHER_CTX_ctrl(pCurCTX, EVP_CTRL_AEAD_SET_IVLEN, iv.size(), NULL);
 			rv = EVP_DecryptInit_ex(pCurCTX, NULL, NULL, (unsigned char*) currentKey->getKeyBits().const_byte_str(), iv.byte_str());
 		}
 	}
@@ -388,7 +388,7 @@ bool OSSLEVPSymmetricAlgorithm::decryptInit(const SymmetricKey* key, const SymMo
 
 	EVP_CIPHER_CTX_set_padding(pCurCTX, padding ? 1 : 0);
 
-	if (mode == SymMode::GCM)
+	if (mode == SymMode::GCM || mode == SymMode::ChaCha20Poly1305)
 	{
 		int outLen = 0;
 		if (aad.size() && !EVP_DecryptUpdate(pCurCTX, NULL, &outLen, (unsigned char*) aad.const_byte_str(), aad.size()))
@@ -416,7 +416,7 @@ bool OSSLEVPSymmetricAlgorithm::decryptUpdate(const ByteString& encryptedData, B
 	}
 
 	// AEAD ciphers should not return decrypted data until final is called
-	if (currentCipherMode == SymMode::GCM)
+	if (currentCipherMode == SymMode::GCM || currentCipherMode == SymMode::ChaCha20Poly1305)
 	{
 		data.resize(0);
 		return true;
@@ -469,7 +469,7 @@ bool OSSLEVPSymmetricAlgorithm::decryptFinal(ByteString& data)
 	}
 
 	data.resize(0);
-	if (mode == SymMode::GCM)
+	if (mode == SymMode::GCM || mode == SymMode::ChaCha20Poly1305)
 	{
 		// Check buffer size
 		if (aeadBuffer.size() < tagBytes)
@@ -482,7 +482,7 @@ bool OSSLEVPSymmetricAlgorithm::decryptFinal(ByteString& data)
 		}
 
 		// Set the tag
-		EVP_CIPHER_CTX_ctrl(pCurCTX, EVP_CTRL_GCM_SET_TAG, tagBytes, &aeadBuffer[aeadBuffer.size()-tagBytes]);
+		EVP_CIPHER_CTX_ctrl(pCurCTX, EVP_CTRL_AEAD_SET_TAG, tagBytes, &aeadBuffer[aeadBuffer.size()-tagBytes]);
 
 		// Prepare the output block
 		data.resize(aeadBuffer.size() - tagBytes + getBlockSize());

--- a/src/lib/crypto/OSSLEVPSymmetricAlgorithm.cpp
+++ b/src/lib/crypto/OSSLEVPSymmetricAlgorithm.cpp
@@ -492,6 +492,9 @@ bool OSSLEVPSymmetricAlgorithm::decryptFinal(ByteString& data)
 		{
 			ERROR_MSG("EVP_DecryptUpdate failed: %s", ERR_error_string(ERR_get_error(), NULL));
 
+			// The tag has not been verified yet; do not leave unauthenticated plaintext behind
+			data.wipe();
+
 			clean();
 
 			return false;
@@ -510,6 +513,10 @@ bool OSSLEVPSymmetricAlgorithm::decryptFinal(ByteString& data)
 	if (!rv)
 	{
 		ERROR_MSG("EVP_DecryptFinal failed (0x%08X): %s", rv, ERR_error_string(ERR_get_error(), NULL));
+
+		// The tag has not been verified (or verification failed); do not leave
+		// unauthenticated plaintext behind
+		data.wipe();
 
 		clean();
 

--- a/src/lib/crypto/SymmetricAlgorithm.cpp
+++ b/src/lib/crypto/SymmetricAlgorithm.cpp
@@ -121,7 +121,7 @@ bool SymmetricAlgorithm::decryptUpdate(const ByteString& encryptedData, ByteStri
 	}
 
 	currentBufferSize += encryptedData.size();
-	if (currentCipherMode == SymMode::GCM) {
+	if (currentCipherMode == SymMode::GCM || currentCipherMode == SymMode::ChaCha20Poly1305) {
 		currentAEADBuffer += encryptedData;
 	}
 
@@ -208,6 +208,7 @@ bool SymmetricAlgorithm::isStreamCipher()
 		case SymMode::CTR:
 		case SymMode::GCM:
 		case SymMode::OFB:
+		case SymMode::ChaCha20Poly1305:
 			return true;
 		default:
 			break;

--- a/src/lib/crypto/SymmetricAlgorithm.h
+++ b/src/lib/crypto/SymmetricAlgorithm.h
@@ -45,7 +45,8 @@ struct SymAlgo
 		Unknown,
 		AES,
 		DES,
-		DES3
+		DES3,
+		ChaCha20Poly1305
 	};
 };
 
@@ -59,7 +60,8 @@ struct SymMode
 		CTR,
 		ECB,
 		GCM,
-		OFB
+		OFB,
+		ChaCha20Poly1305
 	};
 };
 

--- a/src/lib/test/SymmetricAlgorithmTests.cpp
+++ b/src/lib/test/SymmetricAlgorithmTests.cpp
@@ -700,6 +700,24 @@ CK_RV SymmetricAlgorithmTests::generateAesKey(CK_SESSION_HANDLE hSession, CK_BBO
 			     &hKey) );
 }
 
+CK_RV SymmetricAlgorithmTests::generateChaCha20Key(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey)
+{
+	CK_MECHANISM mechanism = { CKM_CHACHA20_KEY_GEN, NULL_PTR, 0 };
+	// CK_BBOOL bFalse = CK_FALSE;
+	CK_BBOOL bTrue = CK_TRUE;
+	CK_ATTRIBUTE keyAttribs[] = {
+		{ CKA_TOKEN, &bToken, sizeof(bToken) },
+		{ CKA_PRIVATE, &bPrivate, sizeof(bPrivate) },
+		{ CKA_ENCRYPT, &bTrue, sizeof(bTrue) },
+		{ CKA_DECRYPT, &bTrue, sizeof(bTrue) },
+	};
+
+	hKey = CK_INVALID_HANDLE;
+	return CRYPTOKI_F_PTR( C_GenerateKey(hSession, &mechanism,
+			     keyAttribs, sizeof(keyAttribs)/sizeof(CK_ATTRIBUTE),
+			     &hKey) );
+}
+
 
 inline CK_RV SymmetricAlgorithmTests::importDesKey(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey, const Bytes & vKeyValue )
 {
@@ -1736,6 +1754,67 @@ void SymmetricAlgorithmTests::testAesEncryptDecrypt()
 	encryptDecrypt({CKM_AES_GCM,&gcmParamsWithoutAAD,sizeof(gcmParamsWithoutAAD)},blockSize,hSessionRO,hKey,blockSize*NR_OF_BLOCKS_IN_TEST);
 }
 
+
+void SymmetricAlgorithmTests::testChaCha20Poly1305EncryptDecrypt()
+{
+	CK_RV rv;
+	CK_SESSION_HANDLE hSessionRO;
+
+	CK_BYTE chachaNonce[] = {
+		0xCA, 0xFE, 0xBA, 0xBE, 0xFA, 0xCE,
+		0xDB, 0xAD, 0xDE, 0xCA, 0xF8, 0x88
+	};
+	CK_BYTE chachaAAD[] = {
+		0xFE, 0xED, 0xFA, 0xCE, 0xDE, 0xAD, 0xBE, 0xEF,
+		0xFE, 0xED, 0xFA, 0xCE, 0xDE, 0xAD, 0xBE, 0xEF,
+		0xAB, 0xAD, 0xDA, 0xD2
+	};
+	CK_SALSA20_CHACHA20_POLY1305_PARAMS chachaParamsWithAAD =
+	{
+		&chachaNonce[0],
+		sizeof(chachaNonce)*8,
+		&chachaAAD[0],
+		sizeof(chachaAAD)
+	};
+	CK_SALSA20_CHACHA20_POLY1305_PARAMS chachaParamsWithoutAAD =
+	{
+		&chachaNonce[0],
+		sizeof(chachaNonce)*8,
+		NULL_PTR,
+		0
+	};
+
+	// Just make sure that we finalize any previous tests
+	CRYPTOKI_F_PTR( C_Finalize(NULL_PTR) );
+
+	// Initialize the library and start the test.
+	rv = CRYPTOKI_F_PTR( C_Initialize(NULL_PTR) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Open read-only session
+	rv = CRYPTOKI_F_PTR( C_OpenSession(m_initializedTokenSlotID, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR, &hSessionRO) );
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// Login USER into the session so we can create a private object
+	rv = CRYPTOKI_F_PTR( C_Login(hSessionRO,CKU_USER,m_userPin1,m_userPin1Length) );
+	CPPUNIT_ASSERT(rv==CKR_OK);
+
+	CK_OBJECT_HANDLE hKey = CK_INVALID_HANDLE;
+
+	rv = generateChaCha20Key(hSessionRO,IN_SESSION,IS_PUBLIC,hKey);
+	CPPUNIT_ASSERT(rv == CKR_OK);
+
+	// ChaCha20-Poly1305 is a stream cipher; reuse the AES block size purely
+	// to size the multi-part chunks exercised by the test helper.
+	const int blockSize(0x10);
+
+	encryptDecrypt({CKM_CHACHA20_POLY1305,&chachaParamsWithAAD,sizeof(chachaParamsWithAAD)},blockSize,hSessionRO,hKey,blockSize*NR_OF_BLOCKS_IN_TEST-1);
+	encryptDecrypt({CKM_CHACHA20_POLY1305,&chachaParamsWithAAD,sizeof(chachaParamsWithAAD)},blockSize,hSessionRO,hKey,blockSize*NR_OF_BLOCKS_IN_TEST+1);
+	encryptDecrypt({CKM_CHACHA20_POLY1305,&chachaParamsWithAAD,sizeof(chachaParamsWithAAD)},blockSize,hSessionRO,hKey,blockSize*NR_OF_BLOCKS_IN_TEST);
+	encryptDecrypt({CKM_CHACHA20_POLY1305,&chachaParamsWithoutAAD,sizeof(chachaParamsWithoutAAD)},blockSize,hSessionRO,hKey,blockSize*NR_OF_BLOCKS_IN_TEST-1);
+	encryptDecrypt({CKM_CHACHA20_POLY1305,&chachaParamsWithoutAAD,sizeof(chachaParamsWithoutAAD)},blockSize,hSessionRO,hKey,blockSize*NR_OF_BLOCKS_IN_TEST+1);
+	encryptDecrypt({CKM_CHACHA20_POLY1305,&chachaParamsWithoutAAD,sizeof(chachaParamsWithoutAAD)},blockSize,hSessionRO,hKey,blockSize*NR_OF_BLOCKS_IN_TEST);
+}
 
 void SymmetricAlgorithmTests::testAesWrapUnwrap()
 {

--- a/src/lib/test/SymmetricAlgorithmTests.h
+++ b/src/lib/test/SymmetricAlgorithmTests.h
@@ -43,6 +43,7 @@ class SymmetricAlgorithmTests : public TestsBase
 {
 	CPPUNIT_TEST_SUITE(SymmetricAlgorithmTests);
 	CPPUNIT_TEST(testAesEncryptDecrypt);
+	CPPUNIT_TEST(testChaCha20Poly1305EncryptDecrypt);
 	CPPUNIT_TEST(testDesEncryptDecrypt);
 #ifdef HAVE_AES_KEY_WRAP
 	CPPUNIT_TEST(testAesWrapUnwrap);
@@ -61,6 +62,7 @@ public:
 	using Bytes = std::vector<CK_BYTE>;
 	
 	void testAesEncryptDecrypt();
+	void testChaCha20Poly1305EncryptDecrypt();
 	void testDesEncryptDecrypt();
 	void testAesWrapUnwrap();
 	void testDesWrapUnwrap();
@@ -75,6 +77,7 @@ public:
 protected:
 	CK_RV generateGenericKey(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey);
 	CK_RV generateAesKey(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey);
+	CK_RV generateChaCha20Key(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey);
 #ifndef WITH_FIPS
 	CK_RV generateDesKey(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey);
 	CK_RV generateDes2Key(CK_SESSION_HANDLE hSession, CK_BBOOL bToken, CK_BBOOL bPrivate, CK_OBJECT_HANDLE &hKey);


### PR DESCRIPTION
## Summary
Adds support for the ChaCha20-Poly1305 AEAD cipher (CKM_CHACHA20_POLY1305, CKM_CHACHA20_KEY_GEN), implemented for both the OpenSSL and Botan crypto backends.

- `CKM_CHACHA20_KEY_GEN` generates a 256-bit `CKK_CHACHA20` secret key.
- `CKM_CHACHA20_POLY1305` supports single- and multi-part encrypt/decrypt with associated data (AAD), following the same mechanism-parameter shape (`CK_SALSA20_CHACHA20_POLY1305_PARAMS`) as other PKCS#11 AEAD mechanisms.
- Works under both `--with-crypto-backend=openssl` and `--with-crypto-backend=botan`.

## Test plan
- [x] Added a round-trip PKCS#11-level test (key gen + encrypt/decrypt, single- and multi-part, with/without AAD), mirroring the existing AES-GCM test.
- [x] Full `p11test` suite (82 tests) passes against the Botan backend.
- [x] Full `p11test` suite (82 tests) passes against the OpenSSL backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for generating 256-bit ChaCha20 keys.
  - Added ChaCha20-Poly1305 encryption and decryption, including authenticated data and authentication tags.
  - Added ChaCha20-Poly1305 to supported mechanism reporting.
- **Bug Fixes**
  - Improved parameter validation, including nonce and null-input checks.
  - Improved failure handling to prevent unauthenticated plaintext from being retained.
- **Tests**
  - Added coverage for encryption and decryption with and without authenticated data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->